### PR TITLE
Rename worker method to register

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ interface EmailJob {
   subject: string;
 }
 
-monque.worker<EmailJob>('send-email', async (job) => {
+monque.register<EmailJob>('send-email', async (job) => {
   console.log('Sending email to:', job.data.to);
   await sendEmail(job.data);
 });

--- a/apps/docs/src/content/docs/advanced/atomic-claim.mdx
+++ b/apps/docs/src/content/docs/advanced/atomic-claim.mdx
@@ -97,14 +97,14 @@ Run multiple scheduler instances for high availability:
 const monque1 = new Monque(db, {
   schedulerInstanceId: 'server-a'
 });
-monque1.worker('send-email', emailHandler);
+monque1.register('send-email', emailHandler);
 monque1.start();
 
 // Instance 2 (server-b)  
 const monque2 = new Monque(db, {
   schedulerInstanceId: 'server-b'
 });
-monque2.worker('send-email', emailHandler);
+monque2.register('send-email', emailHandler);
 monque2.start();
 
 // Both compete fairly for jobs

--- a/apps/docs/src/content/docs/advanced/change-streams.mdx
+++ b/apps/docs/src/content/docs/advanced/change-streams.mdx
@@ -268,7 +268,7 @@ const enqueueTime = Date.now();
 
 await monque.enqueue('measured-job', { enqueueTime });
 
-monque.worker('measured-job', async (job) => {
+monque.register('measured-job', async (job) => {
   const pickupLatency = Date.now() - job.data.enqueueTime;
   // Replace `yourMetrics` with your metrics client (Prometheus, StatsD, OpenTelemetry, ...)
   yourMetrics.histogram('monque.pickup_latency_ms', pickupLatency);

--- a/apps/docs/src/content/docs/advanced/heartbeat.mdx
+++ b/apps/docs/src/content/docs/advanced/heartbeat.mdx
@@ -209,7 +209,7 @@ console.log('Last heartbeat:', job.lastHeartbeat);
 For jobs that may exceed `lockTimeout`:
 
 ```typescript
-monque.worker('long-analysis', async (job) => {
+monque.register('long-analysis', async (job) => {
   const chunks = splitIntoChunks(job.data);
   
   for (const chunk of chunks) {

--- a/apps/docs/src/content/docs/advanced/production-checklist.mdx
+++ b/apps/docs/src/content/docs/advanced/production-checklist.mdx
@@ -37,7 +37,7 @@ Jobs may be executed more than once due to:
 import { Monque } from '@monque/core';
 
 // ✅ Good: Check state before mutating
-monque.worker('charge-payment', async (job) => {
+monque.register('charge-payment', async (job) => {
   const { paymentId } = job.data;
   
   const payment = await db.payments.findOne({ _id: paymentId });
@@ -53,7 +53,7 @@ monque.worker('charge-payment', async (job) => {
 });
 
 // ✅ Good: Use database transactions for atomic operations
-monque.worker('transfer-funds', async (job) => {
+monque.register('transfer-funds', async (job) => {
   const { fromAccount, toAccount, amount, transferId } = job.data;
   
   // Use transferId as idempotency key
@@ -212,13 +212,13 @@ const monque = new Monque(db, {
 });
 
 // CPU-bound: low concurrency
-monque.worker('video-transcode', handler, { concurrency: 2 });
+monque.register('video-transcode', handler, { concurrency: 2 });
 
 // I/O-bound: higher concurrency
-monque.worker('api-sync', handler, { concurrency: 10 });
+monque.register('api-sync', handler, { concurrency: 10 });
 
 // External API with rate limits: match the limit
-monque.worker('stripe-webhook', handler, { concurrency: 5 });
+monque.register('stripe-webhook', handler, { concurrency: 5 });
 ```
 
 See [Concurrency Strategy](/monque/core-concepts/workers/#concurrency-strategy) for guidelines.

--- a/apps/docs/src/content/docs/core-concepts/jobs.mdx
+++ b/apps/docs/src/content/docs/core-concepts/jobs.mdx
@@ -216,7 +216,7 @@ Design workers to handle duplicate execution safely:
 </Aside>
 
 ```typescript
-monque.worker('charge-payment', async (job) => {
+monque.register('charge-payment', async (job) => {
   const { paymentId } = job.data;
   
   // Check if already processed
@@ -282,7 +282,7 @@ import { JobStatus } from '@monque/core';
 
 await monque.schedule('0 3 * * *', 'custom-cleanup', {});
 
-monque.worker('custom-cleanup', async () => {
+monque.register('custom-cleanup', async () => {
   // Access the jobs collection via your own MongoDB client.
   // Use the same collection name you configured for Monque (default: 'monque_jobs').
   const collection = db.collection('monque_jobs');

--- a/apps/docs/src/content/docs/core-concepts/retry.mdx
+++ b/apps/docs/src/content/docs/core-concepts/retry.mdx
@@ -100,7 +100,7 @@ monque.on('job:fail', ({ job, error, willRetry }) => {
 ### Via Job Properties
 
 ```typescript
-monque.worker('example', async (job) => {
+monque.register('example', async (job) => {
   if (job.failCount > 0) {
     console.log(`Retry attempt ${job.failCount}`);
     console.log(`Previous error: ${job.failReason}`);
@@ -122,7 +122,7 @@ class PermanentError extends Error {
   }
 }
 
-monque.worker('api-call', async (job) => {
+monque.register('api-call', async (job) => {
   try {
     const response = await fetch(job.data.url);
     
@@ -161,7 +161,7 @@ const circuitBreaker = {
   resetTime: 60000 // 1 minute
 };
 
-monque.worker('external-api', async (job) => {
+monque.register('external-api', async (job) => {
   // Check circuit breaker
   const now = Date.now();
   if (circuitBreaker.failures >= circuitBreaker.threshold) {
@@ -223,7 +223,7 @@ const backgroundMonque = new Monque(db, {
 ### 2. Log Retry Context
 
 ```typescript
-monque.worker('important-job', async (job) => {
+monque.register('important-job', async (job) => {
   const logger = createLogger({
     jobId: job._id,
     attempt: job.failCount + 1,
@@ -270,7 +270,7 @@ monque.on('job:fail', async ({ job, error, willRetry }) => {
 For high-volume systems, add jitter to prevent thundering herd:
 
 ```typescript
-monque.worker('high-volume-job', async (job) => {
+monque.register('high-volume-job', async (job) => {
   if (job.failCount > 0) {
     // Add random delay 0-1000ms to spread out retries
     const jitter = Math.random() * 1000;
@@ -291,7 +291,7 @@ const noRetryMonque = new Monque(db, {
 });
 
 // Or handle in worker
-monque.worker('fire-and-forget', async (job) => {
+monque.register('fire-and-forget', async (job) => {
   try {
     await sendNotification(job.data);
   } catch (error) {

--- a/apps/docs/src/content/docs/core-concepts/workers.mdx
+++ b/apps/docs/src/content/docs/core-concepts/workers.mdx
@@ -23,7 +23,7 @@ Workers are the execution engines of Monque. They pick up jobs and execute your 
 Use the [`worker()`](/monque/api/classes/monque/#worker) method to register a handler for a specific job type:
 
 ```typescript
-monque.worker('job-name', async (job) => {
+monque.register('job-name', async (job) => {
   // Your processing logic
 });
 ```
@@ -52,7 +52,7 @@ monque.worker<ImageProcessJob>('process-image', async (job) => {
 Configure worker-specific settings via [`WorkerOptions`](/monque/api/interfaces/workeroptions/):
 
 ```typescript
-monque.worker('heavy-computation', async (job) => {
+monque.register('heavy-computation', async (job) => {
   await compute(job.data);
 }, {
   concurrency: 2 // Only 2 concurrent jobs (overrides defaultConcurrency)
@@ -112,7 +112,7 @@ This prevents two scheduler instances from claiming the same pending job at the 
 Your handler function is called with the full job document:
 
 ```typescript
-monque.worker('example', async (job) => {
+monque.register('example', async (job) => {
   console.log(job._id);      // ObjectId
   console.log(job.name);     // 'example'
   console.log(job.data);     // Your payload
@@ -132,7 +132,7 @@ monque.worker('example', async (job) => {
 If your handler throws or returns a rejected promise, the job is automatically retried:
 
 ```typescript
-monque.worker('flaky-api', async (job) => {
+monque.register('flaky-api', async (job) => {
   const response = await fetch(job.data.apiUrl);
   if (!response.ok) {
     throw new Error(`API returned ${response.status}`);
@@ -146,7 +146,7 @@ monque.worker('flaky-api', async (job) => {
 To control retry behavior for expected failures, you can check `job.failCount` or throw `MonqueError`. Note that throwing any error inside a `monque.worker` handler will trigger the retry policy by default.
 
 ```typescript
-monque.worker('check-external-resource', async (job) => {
+monque.register('check-external-resource', async (job) => {
   // Check if resource exists before retrying expensive operations
   if (job.failCount > 0) {
     const exists = await checkResourceExists(job.data.resourceId);
@@ -180,13 +180,13 @@ const monque = new Monque(db, {
 
 ```typescript
 // Low-priority background tasks: higher concurrency
-monque.worker('log-analytics', handler, { concurrency: 20 });
+monque.register('log-analytics', handler, { concurrency: 20 });
 
 // Resource-intensive tasks: lower concurrency
-monque.worker('video-transcode', handler, { concurrency: 2 });
+monque.register('video-transcode', handler, { concurrency: 2 });
 
 // External API calls: match rate limits
-monque.worker('api-sync', handler, { concurrency: 5 });
+monque.register('api-sync', handler, { concurrency: 5 });
 ```
 
 ### Concurrency Strategy
@@ -227,8 +227,8 @@ Workers can be registered before or after `start()`:
   <TabItem label="Before Start (Recommended)">
     ```typescript
     // Register all workers first
-    monque.worker('job-a', handlerA);
-    monque.worker('job-b', handlerB);
+    monque.register('job-a', handlerA);
+    monque.register('job-b', handlerB);
     
     // Then start processing
     monque.start();
@@ -240,7 +240,7 @@ Workers can be registered before or after `start()`:
     
     // Workers registered after start begin processing
     // on the next poll cycle
-    monque.worker('dynamic-worker', handler);
+    monque.register('dynamic-worker', handler);
     ```
   </TabItem>
 </Tabs>
@@ -257,11 +257,11 @@ Each worker should do one thing well:
 
 ```typescript
 // ✅ Good - Single responsibility
-monque.worker('send-email', sendEmailHandler);
-monque.worker('update-stats', updateStatsHandler);
+monque.register('send-email', sendEmailHandler);
+monque.register('update-stats', updateStatsHandler);
 
 // ❌ Bad - Too much in one handler
-monque.worker('process-order', async (job) => {
+monque.register('process-order', async (job) => {
   await sendConfirmationEmail();
   await updateInventory();
   await notifyShipping();
@@ -274,7 +274,7 @@ monque.worker('process-order', async (job) => {
 Design for idempotency:
 
 ```typescript
-monque.worker('sync-data', async (job) => {
+monque.register('sync-data', async (job) => {
   const { batchId } = job.data;
   
   // Track progress in external state
@@ -324,7 +324,7 @@ monque.on('job:fail', ({ job, error, willRetry }) => {
 
 ## API Reference
 
-- [`Monque.worker()`](/monque/api/classes/monque/#worker) - Register a worker handler
+- [`Monque.register()`](/monque/api/classes/monque/#worker) - Register a worker handler
 - [`Monque.start()`](/monque/api/classes/monque/#start) - Start the scheduler
 - [`Monque.stop()`](/monque/api/classes/monque/#stop) - Graceful shutdown
 - [`Monque.now()`](/monque/api/classes/monque/#now) - Immediate job execution

--- a/apps/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/src/content/docs/getting-started/quick-start.mdx
@@ -56,7 +56,7 @@ interface EmailJobData {
 Workers process jobs of a specific type:
 
 ```typescript
-monque.worker<EmailJobData>('send-email', async (job) => {
+monque.register<EmailJobData>('send-email', async (job) => {
   console.log(`📧 Sending email to ${job.data.to}`);
   
   // Your email sending logic here
@@ -169,7 +169,7 @@ async function main() {
   await monque.initialize();
 
   // Register worker
-  monque.worker<EmailJobData>('send-email', async (job) => {
+  monque.register<EmailJobData>('send-email', async (job) => {
     console.log(`📧 Sending to ${job.data.to}: ${job.data.subject}`);
     // Simulate sending email
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -47,7 +47,7 @@ interface EmailJob {
 }
 
 // Register a worker with type safety
-monque.worker<EmailJob>('send-email', async (job) => {
+monque.register<EmailJob>('send-email', async (job) => {
   console.log(`Sending email to ${job.data.to}`);
   await sendEmail(job.data.to, job.data.subject, job.data.body);
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,7 +42,7 @@ const monque = new Monque(client.db('myapp'), {
 await monque.initialize();
 
 // Register workers
-monque.worker('send-email', async (job) => {
+monque.register('send-email', async (job) => {
   await sendEmail(job.data.to, job.data.subject);
 });
 
@@ -81,7 +81,7 @@ Creates a new Monque instance.
 - `enqueue(name, data, options?)` - Enqueue a job
 - `now(name, data)` - Enqueue for immediate processing
 - `schedule(cron, name, data)` - Schedule recurring job
-- `worker(name, handler, options?)` - Register a worker
+- `register(name, handler, options?)` - Register a worker
 - `start()` - Start processing jobs
 - `stop()` - Graceful shutdown
 - `isHealthy()` - Check scheduler health

--- a/packages/core/src/scheduler/monque.ts
+++ b/packages/core/src/scheduler/monque.ts
@@ -94,7 +94,7 @@ type EmailJob = {};
 *   body: string
 * }
  *
- * monque.worker<EmailJob>('send-email', async (job) =>
+ * monque.register<EmailJob>('send-email', async (job) =>
 {
 	*   await emailService.send(job.data.to, job.data.subject, job.data.body)
 	*
@@ -665,7 +665,7 @@ export class Monque extends EventEmitter {
 	 *   body: string;
 	 * }
 	 *
-	 * monque.worker<EmailJob>('send-email', async (job) => {
+	 * monque.register<EmailJob>('send-email', async (job) => {
 	 *   await emailService.send(job.data.to, job.data.subject, job.data.body);
 	 * });
 	 * ```
@@ -673,7 +673,7 @@ export class Monque extends EventEmitter {
 	 * @example Worker with custom concurrency
 	 * ```typescript
 	 * // Limit to 2 concurrent video processing jobs (resource-intensive)
-	 * monque.worker('process-video', async (job) => {
+	 * monque.register('process-video', async (job) => {
 	 *   await videoProcessor.transcode(job.data.videoId);
 	 * }, { concurrency: 2 });
 	 * ```
@@ -681,12 +681,12 @@ export class Monque extends EventEmitter {
 	 * @example Replacing an existing worker
 	 * ```typescript
 	 * // Replace the existing handler for 'send-email'
-	 * monque.worker('send-email', newEmailHandler, { replace: true });
+	 * monque.register('send-email', newEmailHandler, { replace: true });
 	 * ```
 	 *
 	 * @example Worker with error handling
 	 * ```typescript
-	 * monque.worker('sync-user', async (job) => {
+	 * monque.register('sync-user', async (job) => {
 	 *   try {
 	 *     await externalApi.syncUser(job.data.userId);
 	 *   } catch (error) {
@@ -697,7 +697,7 @@ export class Monque extends EventEmitter {
 	 * });
 	 * ```
 	 */
-	worker<T>(name: string, handler: JobHandler<T>, options: WorkerOptions = {}): void {
+	register<T>(name: string, handler: JobHandler<T>, options: WorkerOptions = {}): void {
 		const concurrency = options.concurrency ?? this.options.defaultConcurrency;
 
 		// Check for existing worker and throw unless replace is explicitly true
@@ -730,8 +730,8 @@ export class Monque extends EventEmitter {
 	 * const monque = new Monque(db);
 	 * await monque.initialize();
 	 *
-	 * monque.worker('send-email', emailHandler);
-	 * monque.worker('process-order', orderHandler);
+	 * monque.register('send-email', emailHandler);
+	 * monque.register('process-order', orderHandler);
 	 *
 	 * monque.start(); // Begin processing jobs
 	 * ```

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -118,8 +118,8 @@ export class ShutdownTimeoutError extends MonqueError {
  * @example
  * ```typescript
  * try {
- *   monque.worker('send-email', handler1);
- *   monque.worker('send-email', handler2); // throws
+ *   monque.register('send-email', handler1);
+ *   monque.register('send-email', handler2); // throws
  * } catch (error) {
  *   if (error instanceof WorkerRegistrationError) {
  *     console.error('Worker already registered for:', error.jobName);
@@ -127,7 +127,7 @@ export class ShutdownTimeoutError extends MonqueError {
  * }
  *
  * // To intentionally replace a worker:
- * monque.worker('send-email', handler2, { replace: true });
+ * monque.register('send-email', handler2, { replace: true });
  * ```
  */
 export class WorkerRegistrationError extends MonqueError {

--- a/packages/core/src/workers/types.ts
+++ b/packages/core/src/workers/types.ts
@@ -5,7 +5,7 @@ import type { JobHandler, PersistedJob } from '@/jobs';
  *
  * @example
  * ```typescript
- * monque.worker('send-email', emailHandler, {
+ * monque.register('send-email', emailHandler, {
  *   concurrency: 3,
  * });
  * ```

--- a/packages/core/tests/integration/atomic-claim.test.ts
+++ b/packages/core/tests/integration/atomic-claim.test.ts
@@ -59,7 +59,7 @@ describe('atomic job claiming', () => {
 			await monque.initialize();
 
 			let processedJob: Job | null = null;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async (job) => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async (job) => {
 				processedJob = job;
 				// Hold the job to verify claimedBy while processing
 				await new Promise((resolve) => setTimeout(resolve, 200));
@@ -97,7 +97,7 @@ describe('atomic job claiming', () => {
 				completed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				// Quick completion
 			});
 
@@ -132,7 +132,7 @@ describe('atomic job claiming', () => {
 				}
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Intentional failure');
 			});
 
@@ -168,7 +168,7 @@ describe('atomic job claiming', () => {
 			});
 
 			let attempts = 0;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				attempts++;
 				if (attempts === 1) {
 					throw new Error('First attempt fails');
@@ -237,9 +237,9 @@ describe('atomic job claiming', () => {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			};
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, createHandler('instance-1'));
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, createHandler('instance-2'));
-			monque3.worker(TEST_CONSTANTS.JOB_NAME, createHandler('instance-3'));
+			monque1.register(TEST_CONSTANTS.JOB_NAME, createHandler('instance-1'));
+			monque2.register(TEST_CONSTANTS.JOB_NAME, createHandler('instance-2'));
+			monque3.register(TEST_CONSTANTS.JOB_NAME, createHandler('instance-3'));
 
 			// Enqueue a single job
 			await monque1.enqueue(TEST_CONSTANTS.JOB_NAME, { id: 1 });
@@ -305,8 +305,8 @@ describe('atomic job claiming', () => {
 				await new Promise((resolve) => setTimeout(resolve, 20));
 			};
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			// Enqueue jobs
 			for (let i = 0; i < jobCount; i++) {
@@ -370,7 +370,7 @@ describe('atomic job claiming', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -399,7 +399,7 @@ describe('atomic job claiming', () => {
 			await monque.initialize();
 
 			let processed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processed = true;
 			});
 

--- a/packages/core/tests/integration/change-streams.test.ts
+++ b/packages/core/tests/integration/change-streams.test.ts
@@ -61,7 +61,7 @@ describe('change streams', () => {
 				connected = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connected, { timeout: 5000 });
@@ -86,7 +86,7 @@ describe('change streams', () => {
 				closed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connected, { timeout: 5000 });
@@ -109,7 +109,7 @@ describe('change streams', () => {
 			let startTime: number;
 			let processingTime: number | null = null;
 
-			monque.worker<{ value: number }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ value: number }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				processingTime = Date.now() - startTime;
 			});
 
@@ -145,7 +145,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			const processedIds: number[] = [];
-			monque.worker<{ id: number }>(TEST_CONSTANTS.JOB_NAME, async (job) => {
+			monque.register<{ id: number }>(TEST_CONSTANTS.JOB_NAME, async (job) => {
 				processedIds.push(job.data.id);
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			});
@@ -182,7 +182,7 @@ describe('change streams', () => {
 
 			let attempts = 0;
 			let completed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				attempts++;
 				if (attempts === 1) {
 					throw new Error('First attempt fails');
@@ -216,7 +216,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let executions = 0;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				executions++;
 			});
 
@@ -256,7 +256,7 @@ describe('change streams', () => {
 				});
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 
 			let connected = false;
 			monque.on('changestream:connected', () => {
@@ -289,7 +289,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let processed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processed = true;
 			});
 
@@ -321,7 +321,7 @@ describe('change streams', () => {
 				errorEvents.push(payload);
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 
 			let connected = false;
 			monque.on('changestream:connected', () => {
@@ -374,7 +374,7 @@ describe('change streams', () => {
 				errorEvents.push(payload);
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connectionCount >= 1, { timeout: 5000 });
@@ -428,7 +428,7 @@ describe('change streams', () => {
 			});
 
 			let processed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processed = true;
 			});
 
@@ -458,7 +458,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let processCount = 0;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processCount++;
 			});
 
@@ -494,7 +494,7 @@ describe('change streams', () => {
 				closed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connected, { timeout: 5000 });
@@ -514,7 +514,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let processedAfterStop = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processedAfterStop = true;
 			});
 
@@ -584,8 +584,8 @@ describe('change streams', () => {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			};
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			let connected1 = false;
 			let connected2 = false;
@@ -629,7 +629,7 @@ describe('change streams', () => {
 			const latencies: number[] = [];
 			let processed = 0;
 
-			monque.worker<{ startTime: number }>(TEST_CONSTANTS.JOB_NAME, async (job) => {
+			monque.register<{ startTime: number }>(TEST_CONSTANTS.JOB_NAME, async (job) => {
 				latencies.push(Date.now() - job.data.startTime);
 				processed++;
 			});

--- a/packages/core/tests/integration/concurrency.test.ts
+++ b/packages/core/tests/integration/concurrency.test.ts
@@ -78,7 +78,7 @@ describe('Concurrency & Scalability', () => {
 
 		// Register worker on all instances
 		for (const monque of monqueInstances) {
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 			monque.on('job:error', (payload) => processingErrors.push(payload.error));
 		}
 

--- a/packages/core/tests/integration/events.test.ts
+++ b/packages/core/tests/integration/events.test.ts
@@ -63,7 +63,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			});
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -92,7 +92,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -125,7 +125,7 @@ describe('Monitor Job Lifecycle Events', () => {
 
 			const error = new Error('Task failed');
 			const handler = vi.fn().mockRejectedValue(error);
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -155,7 +155,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			});
 
 			const handler = vi.fn().mockRejectedValue(new Error('Final failure'));
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -175,7 +175,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			monqueInstances.push(monque);
 
 			// Register a worker so poll() has something to do and reaches the database
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 
 			const errorEvents: MonqueEventMap['job:error'][] = [];
 			monque.on('job:error', (payload) => {
@@ -240,7 +240,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			monque.on('job:start', listener);
 
 			// Register worker and enqueue job
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test1' });
 
 			monque.start();
@@ -276,7 +276,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			});
 
 			// Register worker and enqueue multiple jobs
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test1' });
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test2' });
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test3' });

--- a/packages/core/tests/integration/heartbeat.test.ts
+++ b/packages/core/tests/integration/heartbeat.test.ts
@@ -58,7 +58,7 @@ describe('heartbeat mechanism', () => {
 			await monque.initialize();
 
 			let jobStarted = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				await new Promise((resolve) => setTimeout(resolve, 500));
 			});
@@ -88,7 +88,7 @@ describe('heartbeat mechanism', () => {
 
 			const heartbeatTimestamps: Date[] = [];
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				// Hold the job long enough for multiple heartbeats
 				const collection = db.collection(collectionName);
 
@@ -147,7 +147,7 @@ describe('heartbeat mechanism', () => {
 				completed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				// Quick completion
 			});
 
@@ -178,7 +178,7 @@ describe('heartbeat mechanism', () => {
 			await monque.initialize();
 
 			let jobStarted = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				await new Promise((resolve) => setTimeout(resolve, 500));
 			});
@@ -205,7 +205,7 @@ describe('heartbeat mechanism', () => {
 			await monque.initialize();
 
 			let jobStarted = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				await new Promise((resolve) => setTimeout(resolve, 200));
 			});
@@ -324,7 +324,7 @@ describe('heartbeat mechanism', () => {
 				resolveJob = resolve;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				// Wait until we signal completion
 				await jobPromise;

--- a/packages/core/tests/integration/locking.test.ts
+++ b/packages/core/tests/integration/locking.test.ts
@@ -60,7 +60,7 @@ describe('atomic job locking', () => {
 				// Hold the job for a moment to inspect state
 				await new Promise((r) => setTimeout(r, 200));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			monque.start();
@@ -89,7 +89,7 @@ describe('atomic job locking', () => {
 				jobAcquired = true;
 				await new Promise((r) => setTimeout(r, 200));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 
@@ -144,8 +144,8 @@ describe('atomic job locking', () => {
 				await new Promise((r) => setTimeout(r, 100));
 			});
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			// Enqueue multiple jobs
 			const jobCount = 10;
@@ -201,8 +201,8 @@ describe('atomic job locking', () => {
 				await new Promise((r) => setTimeout(r, 80));
 			});
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			// Enqueue jobs
 			const jobCount = 8;
@@ -263,9 +263,9 @@ describe('atomic job locking', () => {
 			const handler2 = createHandler();
 			const handler3 = createHandler();
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
-			monque3.worker(TEST_CONSTANTS.JOB_NAME, handler3);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque3.register(TEST_CONSTANTS.JOB_NAME, handler3);
 
 			// Enqueue jobs
 			const jobCount = 15;
@@ -303,7 +303,7 @@ describe('atomic job locking', () => {
 				checkDuringProcessing = true;
 				await new Promise((r) => setTimeout(r, 200));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			const collection = db.collection(collectionName);
@@ -343,7 +343,7 @@ describe('atomic job locking', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			monque.start();
@@ -370,7 +370,7 @@ describe('atomic job locking', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((r) => setTimeout(r, 100));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			const collection = db.collection(collectionName);
@@ -413,7 +413,7 @@ describe('atomic job locking', () => {
 			);
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -441,7 +441,7 @@ describe('atomic job locking', () => {
 			);
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 			await new Promise((r) => setTimeout(r, 500));
@@ -465,7 +465,7 @@ describe('atomic job locking', () => {
 			);
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 			await new Promise((r) => setTimeout(r, 500));
@@ -485,7 +485,7 @@ describe('atomic job locking', () => {
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {}, { runAt: futureDate });
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 			await new Promise((r) => setTimeout(r, 500));

--- a/packages/core/tests/integration/recovery.test.ts
+++ b/packages/core/tests/integration/recovery.test.ts
@@ -147,7 +147,7 @@ describe('recovery and cleanup', () => {
 			const jobId = result.insertedId;
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -184,7 +184,7 @@ describe('recovery and cleanup', () => {
 			const jobId = result.insertedId;
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 

--- a/packages/core/tests/integration/retry.test.ts
+++ b/packages/core/tests/integration/retry.test.ts
@@ -68,7 +68,7 @@ describe('Retry Logic', () => {
 			// Handler that fails once
 			let callCount = 0;
 			let failureTime = 0;
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				callCount++;
 				if (callCount === 1) {
 					failureTime = Date.now();
@@ -121,7 +121,7 @@ describe('Retry Logic', () => {
 			// Handler that always fails
 			let callCount = 0;
 			let failureTime = 0;
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				callCount++;
 				failureTime = Date.now();
 				throw new Error(`Attempt ${callCount} fails`);
@@ -177,7 +177,7 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			let failureTime = 0;
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				failureTime = Date.now();
 				throw new Error('Always fails');
 			});
@@ -217,7 +217,7 @@ describe('Retry Logic', () => {
 			monqueInstances.push(monque);
 			await monque.initialize();
 
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Always fails');
 			});
 
@@ -251,7 +251,7 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			const errorMessage = 'Connection timeout to external API';
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error(errorMessage);
 			});
 
@@ -285,7 +285,7 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			let callCount = 0;
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				callCount++;
 				throw new Error(`Failure #${callCount}`);
 			});
@@ -325,7 +325,7 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			// Sync throw handler
-			monque.worker<{ type: string }>(TEST_CONSTANTS.JOB_NAME, (job) => {
+			monque.register<{ type: string }>(TEST_CONSTANTS.JOB_NAME, (job) => {
 				if (job.data.type === 'sync') {
 					throw new Error('Sync error');
 				}
@@ -363,7 +363,7 @@ describe('Retry Logic', () => {
 			monqueInstances.push(monque);
 			await monque.initialize();
 
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Temporary failure');
 			});
 
@@ -400,7 +400,7 @@ describe('Retry Logic', () => {
 			monqueInstances.push(monque);
 			await monque.initialize();
 
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Persistent failure');
 			});
 
@@ -442,7 +442,7 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			let failCount = 0;
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				failCount++;
 				throw new Error(`Failure ${failCount}`);
 			});
@@ -480,7 +480,7 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			let handlerCalls = 0;
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				handlerCalls++;
 			});
 
@@ -520,7 +520,7 @@ describe('Retry Logic', () => {
 				metadata: { key: 'value' },
 			};
 
-			monque.worker<typeof jobData>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<typeof jobData>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Failure');
 			});
 
@@ -565,7 +565,7 @@ describe('Retry Logic', () => {
 				failEvents.push(event);
 			});
 
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Temporary failure');
 			});
 
@@ -599,7 +599,7 @@ describe('Retry Logic', () => {
 				failEvents.push(event);
 			});
 
-			monque.worker<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Final failure');
 			});
 

--- a/packages/core/tests/integration/schedule.test.ts
+++ b/packages/core/tests/integration/schedule.test.ts
@@ -436,7 +436,7 @@ describe('schedule()', () => {
 			const handler = vi.fn((job: Job) => {
 				handlerCalls.push(job);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a job with a cron that runs every minute
 			// We'll manually set nextRunAt to now so it runs immediately
@@ -473,7 +473,7 @@ describe('schedule()', () => {
 			const handler = vi.fn((job: Job) => {
 				processedJob = job;
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Use a specific cron expression for predictable timing
 			const cronExpression = '0 * * * *'; // Every hour at minute 0
@@ -511,7 +511,7 @@ describe('schedule()', () => {
 				}
 				// Second call succeeds
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const job = await monque.schedule(
@@ -563,7 +563,7 @@ describe('schedule()', () => {
 			const handler = vi.fn(() => {
 				throw new Error('Always fails');
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const cronExpression = '*/30 * * * *'; // Every 30 minutes
@@ -610,7 +610,7 @@ describe('schedule()', () => {
 				}
 				// Second call succeeds
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job that runs hourly
 			const cronExpression = '0 * * * *';
@@ -664,7 +664,7 @@ describe('schedule()', () => {
 			const handler = vi.fn(() => {
 				processed = true;
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Enqueue a one-time job (not scheduled with cron)
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { oneTime: true });
@@ -694,7 +694,7 @@ describe('schedule()', () => {
 			});
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const job = await monque.schedule(
@@ -732,7 +732,7 @@ describe('schedule()', () => {
 					throw new Error('Test failure reason');
 				}
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const job = await monque.schedule(

--- a/packages/core/tests/integration/shutdown.test.ts
+++ b/packages/core/tests/integration/shutdown.test.ts
@@ -57,7 +57,7 @@ describe('stop() - Graceful Shutdown', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -88,7 +88,7 @@ describe('stop() - Graceful Shutdown', () => {
 			const handler = vi.fn((job: Job) => {
 				processedJobs.push(job);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Enqueue first job
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { order: 1 });
@@ -163,7 +163,7 @@ describe('stop() - Graceful Shutdown', () => {
 				await new Promise((resolve) => setTimeout(resolve, 500));
 				jobCompleted = true;
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -202,7 +202,7 @@ describe('stop() - Graceful Shutdown', () => {
 				await new Promise((resolve) => setTimeout(resolve, 100 + job.data.order * 100));
 				completedJobs.push(job.data.order);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Enqueue multiple jobs
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { order: 1 });
@@ -238,7 +238,7 @@ describe('stop() - Graceful Shutdown', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -273,7 +273,7 @@ describe('stop() - Graceful Shutdown', () => {
 				jobStarted();
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Set up event listener before starting
 			const errorEvents: MonqueEventMap['job:error'][] = [];
@@ -316,7 +316,7 @@ describe('stop() - Graceful Shutdown', () => {
 				jobStarted();
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Set up event listener
 			let shutdownError: ShutdownTimeoutError | undefined;
@@ -364,7 +364,7 @@ describe('stop() - Graceful Shutdown', () => {
 				jobStarted();
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			let errorEmitted = false;
 			monque.on('job:error', () => {
@@ -405,7 +405,7 @@ describe('stop() - Graceful Shutdown', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((resolve) => setTimeout(resolve, 100));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			let errorEmitted = false;
 			monque.on('job:error', () => {

--- a/repomix-core.md
+++ b/repomix-core.md
@@ -1043,7 +1043,7 @@ import type { JobHandler, PersistedJob } from '@/jobs';
  *
  * @example
  * ```typescript
- * monque.worker('send-email', emailHandler, {
+ * monque.register('send-email', emailHandler, {
  *   concurrency: 3,
  * });
  * ```
@@ -1140,7 +1140,7 @@ describe('atomic job claiming', () => {
 			await monque.initialize();
 
 			let processedJob: Job | null = null;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async (job) => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async (job) => {
 				processedJob = job;
 				// Hold the job to verify claimedBy while processing
 				await new Promise((resolve) => setTimeout(resolve, 200));
@@ -1178,7 +1178,7 @@ describe('atomic job claiming', () => {
 				completed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				// Quick completion
 			});
 
@@ -1213,7 +1213,7 @@ describe('atomic job claiming', () => {
 				}
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				throw new Error('Intentional failure');
 			});
 
@@ -1249,7 +1249,7 @@ describe('atomic job claiming', () => {
 			});
 
 			let attempts = 0;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				attempts++;
 				if (attempts === 1) {
 					throw new Error('First attempt fails');
@@ -1318,9 +1318,9 @@ describe('atomic job claiming', () => {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			};
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, createHandler('instance-1'));
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, createHandler('instance-2'));
-			monque3.worker(TEST_CONSTANTS.JOB_NAME, createHandler('instance-3'));
+			monque1.register(TEST_CONSTANTS.JOB_NAME, createHandler('instance-1'));
+			monque2.register(TEST_CONSTANTS.JOB_NAME, createHandler('instance-2'));
+			monque3.register(TEST_CONSTANTS.JOB_NAME, createHandler('instance-3'));
 
 			// Enqueue a single job
 			await monque1.enqueue(TEST_CONSTANTS.JOB_NAME, { id: 1 });
@@ -1386,8 +1386,8 @@ describe('atomic job claiming', () => {
 				await new Promise((resolve) => setTimeout(resolve, 20));
 			};
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			// Enqueue jobs
 			for (let i = 0; i < jobCount; i++) {
@@ -1451,7 +1451,7 @@ describe('atomic job claiming', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -1480,7 +1480,7 @@ describe('atomic job claiming', () => {
 			await monque.initialize();
 
 			let processed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processed = true;
 			});
 
@@ -1561,7 +1561,7 @@ describe('change streams', () => {
 				connected = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connected, { timeout: 5000 });
@@ -1586,7 +1586,7 @@ describe('change streams', () => {
 				closed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connected, { timeout: 5000 });
@@ -1682,7 +1682,7 @@ describe('change streams', () => {
 
 			let attempts = 0;
 			let completed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				attempts++;
 				if (attempts === 1) {
 					throw new Error('First attempt fails');
@@ -1716,7 +1716,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let executions = 0;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				executions++;
 			});
 
@@ -1756,7 +1756,7 @@ describe('change streams', () => {
 				});
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 
 			let connected = false;
 			monque.on('changestream:connected', () => {
@@ -1789,7 +1789,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let processed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processed = true;
 			});
 
@@ -1821,7 +1821,7 @@ describe('change streams', () => {
 				errorEvents.push(payload);
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 
 			let connected = false;
 			monque.on('changestream:connected', () => {
@@ -1874,7 +1874,7 @@ describe('change streams', () => {
 				errorEvents.push(payload);
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connectionCount >= 1, { timeout: 5000 });
@@ -1928,7 +1928,7 @@ describe('change streams', () => {
 			});
 
 			let processed = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processed = true;
 			});
 
@@ -1958,7 +1958,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let processCount = 0;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processCount++;
 			});
 
@@ -1994,7 +1994,7 @@ describe('change streams', () => {
 				closed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			monque.start();
 
 			await waitFor(async () => connected, { timeout: 5000 });
@@ -2014,7 +2014,7 @@ describe('change streams', () => {
 			await monque.initialize();
 
 			let processedAfterStop = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				processedAfterStop = true;
 			});
 
@@ -2084,8 +2084,8 @@ describe('change streams', () => {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			};
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			let connected1 = false;
 			let connected2 = false;
@@ -2223,7 +2223,7 @@ describe('heartbeat mechanism', () => {
 			await monque.initialize();
 
 			let jobStarted = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				await new Promise((resolve) => setTimeout(resolve, 500));
 			});
@@ -2253,7 +2253,7 @@ describe('heartbeat mechanism', () => {
 
 			const heartbeatTimestamps: Date[] = [];
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				// Hold the job long enough for multiple heartbeats
 				const collection = db.collection(collectionName);
 
@@ -2312,7 +2312,7 @@ describe('heartbeat mechanism', () => {
 				completed = true;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				// Quick completion
 			});
 
@@ -2343,7 +2343,7 @@ describe('heartbeat mechanism', () => {
 			await monque.initialize();
 
 			let jobStarted = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				await new Promise((resolve) => setTimeout(resolve, 500));
 			});
@@ -2370,7 +2370,7 @@ describe('heartbeat mechanism', () => {
 			await monque.initialize();
 
 			let jobStarted = false;
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				await new Promise((resolve) => setTimeout(resolve, 200));
 			});
@@ -2489,7 +2489,7 @@ describe('heartbeat mechanism', () => {
 				resolveJob = resolve;
 			});
 
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {
 				jobStarted = true;
 				// Wait until we signal completion
 				await jobPromise;
@@ -3596,8 +3596,8 @@ export class ShutdownTimeoutError extends MonqueError {
  * @example
  * ```typescript
  * try {
- *   monque.worker('send-email', handler1);
- *   monque.worker('send-email', handler2); // throws
+ *   monque.register('send-email', handler1);
+ *   monque.register('send-email', handler2); // throws
  * } catch (error) {
  *   if (error instanceof WorkerRegistrationError) {
  *     console.error('Worker already registered for:', error.jobName);
@@ -3605,7 +3605,7 @@ export class ShutdownTimeoutError extends MonqueError {
  * }
  *
  * // To intentionally replace a worker:
- * monque.worker('send-email', handler2, { replace: true });
+ * monque.register('send-email', handler2, { replace: true });
  * ```
  */
 export class WorkerRegistrationError extends MonqueError {
@@ -3705,7 +3705,7 @@ describe('Concurrency & Scalability', () => {
 
 		// Register worker on all instances
 		for (const monque of monqueInstances) {
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 			monque.on('job:error', (payload) => processingErrors.push(payload.error));
 		}
 
@@ -4871,7 +4871,7 @@ describe('atomic job locking', () => {
 				// Hold the job for a moment to inspect state
 				await new Promise((r) => setTimeout(r, 200));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			monque.start();
@@ -4900,7 +4900,7 @@ describe('atomic job locking', () => {
 				jobAcquired = true;
 				await new Promise((r) => setTimeout(r, 200));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 
@@ -4955,8 +4955,8 @@ describe('atomic job locking', () => {
 				await new Promise((r) => setTimeout(r, 100));
 			});
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			// Enqueue multiple jobs
 			const jobCount = 10;
@@ -5012,8 +5012,8 @@ describe('atomic job locking', () => {
 				await new Promise((r) => setTimeout(r, 80));
 			});
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
 
 			// Enqueue jobs
 			const jobCount = 8;
@@ -5074,9 +5074,9 @@ describe('atomic job locking', () => {
 			const handler2 = createHandler();
 			const handler3 = createHandler();
 
-			monque1.worker(TEST_CONSTANTS.JOB_NAME, handler1);
-			monque2.worker(TEST_CONSTANTS.JOB_NAME, handler2);
-			monque3.worker(TEST_CONSTANTS.JOB_NAME, handler3);
+			monque1.register(TEST_CONSTANTS.JOB_NAME, handler1);
+			monque2.register(TEST_CONSTANTS.JOB_NAME, handler2);
+			monque3.register(TEST_CONSTANTS.JOB_NAME, handler3);
 
 			// Enqueue jobs
 			const jobCount = 15;
@@ -5114,7 +5114,7 @@ describe('atomic job locking', () => {
 				checkDuringProcessing = true;
 				await new Promise((r) => setTimeout(r, 200));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			const collection = db.collection(collectionName);
@@ -5154,7 +5154,7 @@ describe('atomic job locking', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			monque.start();
@@ -5181,7 +5181,7 @@ describe('atomic job locking', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((r) => setTimeout(r, 100));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {});
 			const collection = db.collection(collectionName);
@@ -5224,7 +5224,7 @@ describe('atomic job locking', () => {
 			);
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -5252,7 +5252,7 @@ describe('atomic job locking', () => {
 			);
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 			await new Promise((r) => setTimeout(r, 500));
@@ -5276,7 +5276,7 @@ describe('atomic job locking', () => {
 			);
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 			await new Promise((r) => setTimeout(r, 500));
@@ -5296,7 +5296,7 @@ describe('atomic job locking', () => {
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, {}, { runAt: futureDate });
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 			await new Promise((r) => setTimeout(r, 500));
@@ -5460,7 +5460,7 @@ describe('recovery and cleanup', () => {
 			const jobId = result.insertedId;
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -5497,7 +5497,7 @@ describe('recovery and cleanup', () => {
 			const jobId = result.insertedId;
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -6587,7 +6587,7 @@ describe('schedule()', () => {
 			const handler = vi.fn((job: Job) => {
 				handlerCalls.push(job);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a job with a cron that runs every minute
 			// We'll manually set nextRunAt to now so it runs immediately
@@ -6624,7 +6624,7 @@ describe('schedule()', () => {
 			const handler = vi.fn((job: Job) => {
 				processedJob = job;
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Use a specific cron expression for predictable timing
 			const cronExpression = '0 * * * *'; // Every hour at minute 0
@@ -6662,7 +6662,7 @@ describe('schedule()', () => {
 				}
 				// Second call succeeds
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const job = await monque.schedule(
@@ -6714,7 +6714,7 @@ describe('schedule()', () => {
 			const handler = vi.fn(() => {
 				throw new Error('Always fails');
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const cronExpression = '*/30 * * * *'; // Every 30 minutes
@@ -6761,7 +6761,7 @@ describe('schedule()', () => {
 				}
 				// Second call succeeds
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job that runs hourly
 			const cronExpression = '0 * * * *';
@@ -6815,7 +6815,7 @@ describe('schedule()', () => {
 			const handler = vi.fn(() => {
 				processed = true;
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Enqueue a one-time job (not scheduled with cron)
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { oneTime: true });
@@ -6845,7 +6845,7 @@ describe('schedule()', () => {
 			});
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const job = await monque.schedule(
@@ -6883,7 +6883,7 @@ describe('schedule()', () => {
 					throw new Error('Test failure reason');
 				}
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Schedule a recurring job
 			const job = await monque.schedule(
@@ -7044,7 +7044,7 @@ describe('stop() - Graceful Shutdown', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -7075,7 +7075,7 @@ describe('stop() - Graceful Shutdown', () => {
 			const handler = vi.fn((job: Job) => {
 				processedJobs.push(job);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Enqueue first job
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { order: 1 });
@@ -7150,7 +7150,7 @@ describe('stop() - Graceful Shutdown', () => {
 				await new Promise((resolve) => setTimeout(resolve, 500));
 				jobCompleted = true;
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -7189,7 +7189,7 @@ describe('stop() - Graceful Shutdown', () => {
 				await new Promise((resolve) => setTimeout(resolve, 100 + job.data.order * 100));
 				completedJobs.push(job.data.order);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Enqueue multiple jobs
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { order: 1 });
@@ -7225,7 +7225,7 @@ describe('stop() - Graceful Shutdown', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			monque.start();
 
@@ -7260,7 +7260,7 @@ describe('stop() - Graceful Shutdown', () => {
 				jobStarted();
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Set up event listener before starting
 			const errorEvents: MonqueEventMap['job:error'][] = [];
@@ -7303,7 +7303,7 @@ describe('stop() - Graceful Shutdown', () => {
 				jobStarted();
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			// Set up event listener
 			let shutdownError: ShutdownTimeoutError | undefined;
@@ -7351,7 +7351,7 @@ describe('stop() - Graceful Shutdown', () => {
 				jobStarted();
 				await new Promise((resolve) => setTimeout(resolve, 1000));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			let errorEmitted = false;
 			monque.on('job:error', () => {
@@ -7392,7 +7392,7 @@ describe('stop() - Graceful Shutdown', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((resolve) => setTimeout(resolve, 100));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			let errorEmitted = false;
 			monque.on('job:error', () => {
@@ -7688,7 +7688,7 @@ describe('worker()', () => {
 
 			const handler = vi.fn();
 			// Worker registration is synchronous and should not throw
-			expect(() => monque.worker(TEST_CONSTANTS.JOB_NAME, handler)).not.toThrow();
+			expect(() => monque.register(TEST_CONSTANTS.JOB_NAME, handler)).not.toThrow();
 		});
 
 		it('should allow registering multiple workers for different job names', async () => {
@@ -7704,9 +7704,9 @@ describe('worker()', () => {
 			const handler2 = vi.fn();
 			const handler3 = vi.fn();
 
-			monque.worker(jobType1Name, handler1);
-			monque.worker(jobType2Name, handler2);
-			monque.worker(jobType3Name, handler3);
+			monque.register(jobType1Name, handler1);
+			monque.register(jobType2Name, handler2);
+			monque.register(jobType3Name, handler3);
 		});
 
 		it('should throw WorkerRegistrationError when registering same job name twice without replace', async () => {
@@ -7719,11 +7719,11 @@ describe('worker()', () => {
 			const handler1 = vi.fn();
 			const handler2 = vi.fn();
 
-			monque.worker(sameJobName, handler1);
+			monque.register(sameJobName, handler1);
 
 			// Second registration should throw
-			expect(() => monque.worker(sameJobName, handler2)).toThrow(WorkerRegistrationError);
-			expect(() => monque.worker(sameJobName, handler2)).toThrow(
+			expect(() => monque.register(sameJobName, handler2)).toThrow(WorkerRegistrationError);
+			expect(() => monque.register(sameJobName, handler2)).toThrow(
 				`Worker already registered for job name "${sameJobName}"`,
 			);
 		});
@@ -7738,8 +7738,8 @@ describe('worker()', () => {
 			const handler1 = vi.fn();
 			const handler2 = vi.fn();
 
-			monque.worker(sameJobName, handler1);
-			monque.worker(sameJobName, handler2, { replace: true });
+			monque.register(sameJobName, handler1);
+			monque.register(sameJobName, handler2, { replace: true });
 
 			// Enqueue a job and verify only handler2 is called
 			await monque.enqueue(sameJobName, {});
@@ -7761,10 +7761,10 @@ describe('worker()', () => {
 			const handler1 = vi.fn();
 			const handler2 = vi.fn();
 
-			monque.worker(jobName, handler1);
+			monque.register(jobName, handler1);
 
 			try {
-				monque.worker(jobName, handler2);
+				monque.register(jobName, handler2);
 				expect.fail('Should have thrown');
 			} catch (error) {
 				expect(error).toBeInstanceOf(WorkerRegistrationError);
@@ -7781,7 +7781,7 @@ describe('worker()', () => {
 			const handler = vi.fn();
 
 			// Registration with options should succeed
-			expect(() => monque.worker('concurrent-job', handler, { concurrency: 3 })).not.toThrow();
+			expect(() => monque.register('concurrent-job', handler, { concurrency: 3 })).not.toThrow();
 		});
 	});
 
@@ -7793,7 +7793,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { test: true });
 			monque.start();
@@ -7813,7 +7813,7 @@ describe('worker()', () => {
 			const handler = vi.fn((job: Job) => {
 				receivedJobs.push(job);
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			const enqueuedData = { userId: '123', action: 'process' };
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, enqueuedData);
@@ -7842,7 +7842,7 @@ describe('worker()', () => {
 			const handler = vi.fn((job: Job<{ order: number }>) => {
 				processedJobs.push(job.data.order);
 			});
-			monque.worker(orderedJobName, handler);
+			monque.register(orderedJobName, handler);
 
 			// Enqueue jobs with different nextRunAt times (in reverse order)
 			const now = Date.now();
@@ -7865,7 +7865,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(registeredJobName, handler);
+			monque.register(registeredJobName, handler);
 
 			// Enqueue both registered and unregistered job types
 			await monque.enqueue(registeredJobName, {});
@@ -7890,7 +7890,7 @@ describe('worker()', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((r) => setTimeout(r, 50));
 			});
-			monque.worker(asyncJobName, handler);
+			monque.register(asyncJobName, handler);
 
 			await monque.enqueue(asyncJobName, {});
 			monque.start();
@@ -7908,7 +7908,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(completeJobName, handler);
+			monque.register(completeJobName, handler);
 
 			const job = await monque.enqueue(completeJobName, {});
 			monque.start();
@@ -7932,7 +7932,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(unlockJobName, handler);
+			monque.register(unlockJobName, handler);
 
 			const job = await monque.enqueue(unlockJobName, {});
 			monque.start();
@@ -7971,7 +7971,7 @@ describe('worker()', () => {
 				const end = Date.now();
 				timestamps.push({ start, end });
 			});
-			monque.worker(concurrencyJobName, handler);
+			monque.register(concurrencyJobName, handler);
 
 			// Enqueue more jobs than the concurrency limit
 			for (let i = 0; i < 5; i++) {
@@ -8013,7 +8013,7 @@ describe('worker()', () => {
 				const end = Date.now();
 				timestamps.push({ start, end });
 			});
-			monque.worker(limitedJobName, handler, { concurrency: workerConcurrency });
+			monque.register(limitedJobName, handler, { concurrency: workerConcurrency });
 
 			// Enqueue multiple jobs
 			for (let i = 0; i < 3; i++) {
@@ -8068,8 +8068,8 @@ describe('worker()', () => {
 				timestampsB.push({ start, end });
 			});
 
-			monque.worker(jobTypeAName, handlerA, { concurrency: 2 });
-			monque.worker(jobTypeBName, handlerB, { concurrency: 4 });
+			monque.register(jobTypeAName, handlerA, { concurrency: 2 });
+			monque.register(jobTypeBName, handlerB, { concurrency: 4 });
 
 			// Enqueue jobs for both types
 			for (let i = 0; i < 4; i++) {
@@ -8116,7 +8116,7 @@ describe('worker()', () => {
 				await new Promise((r) => setTimeout(r, 100));
 				processedOrder.push(job.data.index);
 			});
-			monque.worker(slotJobName, handler);
+			monque.register(slotJobName, handler);
 
 			// Enqueue 4 jobs
 			for (let i = 0; i < 4; i++) {
@@ -8142,7 +8142,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(noStartJobName, handler);
+			monque.register(noStartJobName, handler);
 
 			await monque.enqueue(noStartJobName, {});
 
@@ -8160,7 +8160,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(stopJobName, handler);
+			monque.register(stopJobName, handler);
 
 			monque.start();
 			await monque.stop();
@@ -8182,7 +8182,7 @@ describe('worker()', () => {
 			await monque.initialize();
 
 			const handler = vi.fn();
-			monque.worker(restartJobName, handler);
+			monque.register(restartJobName, handler);
 
 			monque.start();
 			await monque.stop();
@@ -8842,7 +8842,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			});
 
 			const handler = vi.fn();
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -8871,7 +8871,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			const handler = vi.fn(async () => {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			});
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -8904,7 +8904,7 @@ describe('Monitor Job Lifecycle Events', () => {
 
 			const error = new Error('Task failed');
 			const handler = vi.fn().mockRejectedValue(error);
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -8934,7 +8934,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			});
 
 			const handler = vi.fn().mockRejectedValue(new Error('Final failure'));
-			monque.worker(TEST_CONSTANTS.JOB_NAME, handler);
+			monque.register(TEST_CONSTANTS.JOB_NAME, handler);
 
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test' });
 
@@ -8954,7 +8954,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			monqueInstances.push(monque);
 
 			// Register a worker so poll() has something to do and reaches the database
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 
 			const errorEvents: MonqueEventMap['job:error'][] = [];
 			monque.on('job:error', (payload) => {
@@ -9019,7 +9019,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			monque.on('job:start', listener);
 
 			// Register worker and enqueue job
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test1' });
 
 			monque.start();
@@ -9055,7 +9055,7 @@ describe('Monitor Job Lifecycle Events', () => {
 			});
 
 			// Register worker and enqueue multiple jobs
-			monque.worker(TEST_CONSTANTS.JOB_NAME, async () => {});
+			monque.register(TEST_CONSTANTS.JOB_NAME, async () => {});
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test1' });
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test2' });
 			await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'test3' });
@@ -9926,7 +9926,7 @@ export class Monque extends EventEmitter {
 	 * @example Worker with custom concurrency
 	 * ```typescript
 	 * // Limit to 2 concurrent video processing jobs (resource-intensive)
-	 * monque.worker('process-video', async (job) => {
+	 * monque.register('process-video', async (job) => {
 	 *   await videoProcessor.transcode(job.data.videoId);
 	 * }, { concurrency: 2 });
 	 * ```
@@ -9934,12 +9934,12 @@ export class Monque extends EventEmitter {
 	 * @example Replacing an existing worker
 	 * ```typescript
 	 * // Replace the existing handler for 'send-email'
-	 * monque.worker('send-email', newEmailHandler, { replace: true });
+	 * monque.register('send-email', newEmailHandler, { replace: true });
 	 * ```
 	 *
 	 * @example Worker with error handling
 	 * ```typescript
-	 * monque.worker('sync-user', async (job) => {
+	 * monque.register('sync-user', async (job) => {
 	 *   try {
 	 *     await externalApi.syncUser(job.data.userId);
 	 *   } catch (error) {
@@ -9983,8 +9983,8 @@ export class Monque extends EventEmitter {
 	 * const monque = new Monque(db);
 	 * await monque.initialize();
 	 *
-	 * monque.worker('send-email', emailHandler);
-	 * monque.worker('process-order', orderHandler);
+	 * monque.register('send-email', emailHandler);
+	 * monque.register('process-order', orderHandler);
 	 *
 	 * monque.start(); // Begin processing jobs
 	 * ```
@@ -10973,7 +10973,7 @@ const monque = new Monque(client.db('myapp'), {
 await monque.initialize();
 
 // Register workers
-monque.worker('send-email', async (job) => {
+monque.register('send-email', async (job) => {
   await sendEmail(job.data.to, job.data.subject);
 });
 

--- a/specs/001-monque-scheduler/contracts/job-schema.ts
+++ b/specs/001-monque-scheduler/contracts/job-schema.ts
@@ -325,7 +325,7 @@ export interface MonqueEventMap {
  *
  * @example
  * ```typescript
- * monque.worker('send-email', emailHandler, {
+ * monque.register('send-email', emailHandler, {
  *   concurrency: 3,
  * });
  * ```


### PR DESCRIPTION
Renames the `worker` method to `register` for clearer API semantics—the method registers a job handler, not a worker instance.

### Changes
- Renamed `worker<T>()` → `register<T>()` in `Monque` class
- Updated all JSDoc examples, tests, and documentation

### Usage
```typescript
// Before
monque.worker<EmailJob>('send-email', async (job) => {
  await sendEmail(job.data);
});

// After
monque.register<EmailJob>('send-email', async (job) => {
  await sendEmail(job.data);
});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Renamed job handler registration API from `worker()` to `register()`. Update existing code to use the new method name.

* **Documentation**
  * Updated all examples and references throughout documentation to reflect the renamed registration method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->