### PR TITLE
fix(ci): pin changesets/action to v1.5.3 commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
         run: bun run build
 
       - name: Create Release PR or Publish
-        uses: changesets/action@04d574e831923498156e0b2b93152878063203a3
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
           publish: bunx changeset publish
           version: bunx changeset version


### PR DESCRIPTION
Renovate picked a wrong commit when updating. It had no release/tag commit that contains the built action entrypoint. 