### PR TITLE
chore: updated Node.js requirement; refined Renovate Node tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ bun run dev:docs
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 22+
 - MongoDB 4.0+ (Replica Set required for Change Streams)
 - Bun 1.3.5+ (development only; required to work on this repo)
 

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -12,7 +12,7 @@ import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 Before installing Monque, ensure you have:
 
-- **Node.js 20+** or **Bun 1.0+**
+- **Node.js 22+** or **Bun 1.3+**
 - **MongoDB 4.0+**
   - Monque works with regular polling on standalone MongoDB
   - Change Streams require a replica set or sharded cluster (MongoDB Atlas provides this by default)

--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,13 @@
 			"matchPackageNames": ["node"],
 			"matchUpdateTypes": ["minor", "patch", "pin"],
 			"enabled": false
+		},
+		{
+			"description": "Use major version only for Node.js in GitHub Actions (prevent full version pinning)",
+			"matchPackageNames": ["node"],
+			"matchManagers": ["github-actions"],
+			"matchUpdateTypes": ["major"],
+			"versioning": "regex:^(?<major>\\d+)(\\..*)?$"
 		}
 	]
 }


### PR DESCRIPTION
- Updated Node.js requirements in docs and README to v22+
- Modified renovate.json to prevent full-version pinning for Node.js in GitHub Actions