### PR TITLE
 fix(core): avoid emitting job:cancelled on no-op cancellations

### DIFF
--- a/.changeset/avoid-cancel-noop-event-docs.patch.md
+++ b/.changeset/avoid-cancel-noop-event-docs.patch.md
@@ -1,0 +1,8 @@
+---
+"@monque/docs": patch
+---
+
+Clarify cancellation event semantics in core docs.
+
+- Update core management docs to state `job:cancelled` only emits on a pending→cancelled transition.
+- Keep `cancelJob` docs consistent with idempotent no-op behavior for already-cancelled jobs.

--- a/.changeset/avoid-cancel-noop-event.patch.md
+++ b/.changeset/avoid-cancel-noop-event.patch.md
@@ -1,0 +1,8 @@
+---
+"@monque/core": patch
+---
+
+Avoid emitting `job:cancelled` for no-op cancellations.
+
+- Keep `cancelJob()` idempotent for already-cancelled jobs.
+- Emit `job:cancelled` only when a job transitions from `pending` to `cancelled`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,44 @@
+# Monque Context
+
+Monque is a MongoDB-backed job scheduler. It stores jobs in one collection and coordinates
+workers across scheduler instances with atomic MongoDB writes.
+
+## Domain Vocabulary
+
+**Job** — persisted unit of background work. It has a name, payload, lifecycle status,
+schedule time, retry metadata, and optional recurring schedule.
+
+**Worker** — registered handler for one job name. Worker concurrency limits how many jobs
+with that name can run at once in one scheduler instance.
+
+**Scheduler Instance** — running Monque process identified by `schedulerInstanceId`.
+It claims jobs, sends heartbeats, and releases ownership when work completes.
+
+**Claim** — atomic transition from pending to processing. A claim writes `claimedBy`,
+`lockedAt`, `lastHeartbeat`, and `heartbeatInterval`.
+
+**Owned Job** — processing job whose `claimedBy` matches current scheduler instance.
+Completion and failure transitions require ownership.
+
+**Stale Job** — processing job whose `lockedAt` is older than `lockTimeout`. Stale recovery
+resets it to pending and clears claim fields.
+
+**Heartbeat** — liveness signal written to `lastHeartbeat` while a job is processing.
+It supports monitoring and instance collision checks; stale recovery uses `lockedAt`.
+
+**Pending Notification** — local signal that a pending job exists at `nextRunAt`.
+Change streams, retries, reschedules, recurring completion, and intake use this to reduce
+polling latency.
+
+**Unique Key** — deduplication key scoped by job name and active statuses. Pending and
+processing jobs block duplicates; completed and failed jobs do not.
+
+**Retention** — optional cleanup policy for completed and failed jobs based on `updatedAt`.
+
+## Load-Bearing Rules
+
+- Claims and owned-job transitions use atomic MongoDB preconditions.
+- Stale recovery uses `lockedAt + lockTimeout`, not `lastHeartbeat`.
+- `lastHeartbeat` is still load-bearing for instance collision checks and observability.
+- Public scheduler methods remain on `Monque`; internal modules hide persistence detail.
+- Change streams are an optimization. Polling remains required as safety net and fallback.

--- a/apps/docs/src/content/docs/core-concepts/management.mdx
+++ b/apps/docs/src/content/docs/core-concepts/management.mdx
@@ -32,7 +32,7 @@ const job = await monque.cancelJob('job-id');
 ```
 
 - **Effect**: Status becomes `cancelled`.
-- **Event**: Emits `job:cancelled`.
+- **Event**: Emits `job:cancelled` only when the job transitions from `pending` to `cancelled`.
 - **Constraint**: Cannot cancel `processing`, `completed`, or `failed` jobs (unless they return to pending).
 
 ### Retry a Job

--- a/docs/adr/0001-job-ownership-and-stale-recovery.md
+++ b/docs/adr/0001-job-ownership-and-stale-recovery.md
@@ -1,0 +1,29 @@
+# ADR-0001: Job Ownership And Stale Recovery
+
+## Status
+
+Accepted
+
+## Context
+
+Monque can run multiple scheduler instances against one MongoDB collection. Only one
+instance may process a job at a time, and crashed instances must not leave jobs stuck
+forever.
+
+## Decision
+
+Jobs are claimed with atomic MongoDB updates from `pending` to `processing`. The claim
+writes `claimedBy`, `lockedAt`, `lastHeartbeat`, and `heartbeatInterval`.
+
+Owned-job completion and failure require `status: processing` and `claimedBy` matching
+the current scheduler instance.
+
+Stale recovery treats `lockedAt + lockTimeout` as the source of truth. `lastHeartbeat`
+remains an observability and instance-collision signal, not stale-recovery authority.
+
+## Consequences
+
+Race conditions concentrate in job state transition code.
+
+Long-running jobs must set a lock timeout large enough for expected processing time.
+Heartbeats do not extend the stale-recovery deadline.

--- a/docs/adr/0002-change-streams-with-polling-safety-net.md
+++ b/docs/adr/0002-change-streams-with-polling-safety-net.md
@@ -1,0 +1,28 @@
+# ADR-0002: Change Streams With Polling Safety Net
+
+## Status
+
+Accepted
+
+## Context
+
+Polling alone adds latency. MongoDB change streams can wake workers quickly, but they are
+not available in every MongoDB deployment and can disconnect.
+
+## Decision
+
+Use change streams as the primary notification path when available. Keep polling as both
+fallback and safety net.
+
+When change streams are active, polling uses `safetyPollInterval`. When unavailable or
+disconnected, polling uses `pollInterval`.
+
+Local pending notifications are still emitted after local writes so scheduler latency does
+not depend on change stream cursor timing.
+
+## Consequences
+
+Correctness cannot depend on change streams.
+
+Wakeup routing must handle inserted jobs, jobs becoming pending, future `nextRunAt` values,
+and slots freed by terminal transitions.

--- a/packages/core/src/scheduler/monque.ts
+++ b/packages/core/src/scheduler/monque.ts
@@ -628,7 +628,8 @@ export class Monque extends EventEmitter {
 	/**
 	 * Cancel a pending or scheduled job.
 	 *
-	 * Sets the job status to 'cancelled' and emits a 'job:cancelled' event.
+	 * Sets the job status to 'cancelled' only when canceling from pending status.
+	 * Emits a 'job:cancelled' event only when a state transition occurs.
 	 * If the job is already cancelled, this is a no-op and returns the job.
 	 * Cannot cancel jobs that are currently 'processing', 'completed', or 'failed'.
 	 *

--- a/packages/core/src/scheduler/services/index.ts
+++ b/packages/core/src/scheduler/services/index.ts
@@ -5,6 +5,13 @@ export { JobManager } from './job-manager.js';
 export { JobProcessor } from './job-processor.js';
 export { JobQueryService } from './job-query.js';
 export { JobSelection } from './job-selection.js';
+export { JobStateTransitions } from './job-state-transitions.js';
 export { CLEANUP_STATUSES, LifecycleManager } from './lifecycle-manager.js';
 // Types
-export type { ResolvedMonqueOptions, SchedulerContext } from './types.js';
+export {
+	RETRYABLE_JOB_STATUSES,
+	type ResolvedMonqueOptions,
+	type RetriedJob,
+	type RetryableJobStatusType,
+	type SchedulerContext,
+} from './types.js';

--- a/packages/core/src/scheduler/services/job-manager.ts
+++ b/packages/core/src/scheduler/services/job-manager.ts
@@ -2,9 +2,14 @@ import { ObjectId } from 'mongodb';
 
 import { type BulkOperationResult, type JobSelector, JobStatus, type PersistedJob } from '@/jobs';
 import { buildSelectorQuery } from '@/scheduler';
-import { ConnectionError, JobStateError, MonqueError } from '@/shared';
+import { ConnectionError, MonqueError } from '@/shared';
 
-import type { SchedulerContext } from './types.js';
+import { JobStateTransitions } from './job-state-transitions.js';
+import {
+	RETRYABLE_JOB_STATUSES,
+	type RetryableJobStatusType,
+	type SchedulerContext,
+} from './types.js';
 
 /**
  * Internal service for job lifecycle management operations.
@@ -15,7 +20,11 @@ import type { SchedulerContext } from './types.js';
  * @internal Not part of public API - use Monque class methods instead.
  */
 export class JobManager {
-	constructor(private readonly ctx: SchedulerContext) {}
+	private readonly transitions: JobStateTransitions;
+
+	constructor(private readonly ctx: SchedulerContext) {
+		this.transitions = new JobStateTransitions(ctx);
+	}
 
 	/**
 	 * Cancel a pending or scheduled job.
@@ -35,42 +44,15 @@ export class JobManager {
 	 * ```
 	 */
 	async cancelJob(jobId: string): Promise<PersistedJob<unknown> | null> {
-		if (!ObjectId.isValid(jobId)) return null;
-
-		const _id = new ObjectId(jobId);
-
 		try {
-			const now = new Date();
-			const result = await this.ctx.collection.findOneAndUpdate(
-				{ _id, status: JobStatus.PENDING },
-				{
-					$set: {
-						status: JobStatus.CANCELLED,
-						updatedAt: now,
-					},
-				},
-				{ returnDocument: 'after' },
-			);
-
-			if (!result) {
-				const jobDoc = await this.ctx.collection.findOne({ _id });
-				if (!jobDoc) return null;
-
-				if (jobDoc['status'] === JobStatus.CANCELLED) {
-					return this.ctx.documentToPersistedJob(jobDoc);
-				}
-
-				throw new JobStateError(
-					`Cannot cancel job in status '${jobDoc['status']}'`,
-					jobId,
-					jobDoc['status'],
-					'cancel',
-				);
+			const cancelled = await this.transitions.cancelPending(jobId);
+			if (!cancelled) {
+				return null;
 			}
-
-			const job = this.ctx.documentToPersistedJob(result);
-			this.ctx.emit('job:cancelled', { job });
-			return job;
+			if (cancelled.transitioned) {
+				this.ctx.emit('job:cancelled', { job: cancelled.job });
+			}
+			return cancelled.job;
 		} catch (error) {
 			if (error instanceof MonqueError) {
 				throw error;
@@ -102,62 +84,13 @@ export class JobManager {
 	 * ```
 	 */
 	async retryJob(jobId: string): Promise<PersistedJob<unknown> | null> {
-		if (!ObjectId.isValid(jobId)) return null;
-
-		const _id = new ObjectId(jobId);
-
 		try {
-			const now = new Date();
-			const result = await this.ctx.collection.findOneAndUpdate(
-				{
-					_id,
-					status: { $in: [JobStatus.FAILED, JobStatus.CANCELLED] },
-				},
-				{
-					$set: {
-						status: JobStatus.PENDING,
-						failCount: 0,
-						nextRunAt: now,
-						updatedAt: now,
-					},
-					$unset: {
-						failReason: '',
-						lockedAt: '',
-						claimedBy: '',
-						lastHeartbeat: '',
-					},
-				},
-				{ returnDocument: 'before' },
-			);
-
-			if (!result) {
-				const currentJob = await this.ctx.collection.findOne({ _id });
-				if (!currentJob) return null;
-
-				throw new JobStateError(
-					`Cannot retry job in status '${currentJob['status']}'`,
-					jobId,
-					currentJob['status'],
-					'retry',
-				);
+			const retried = await this.transitions.retryTerminal(jobId);
+			if (!retried) {
+				return null;
 			}
-
-			const previousStatus = result['status'] as 'failed' | 'cancelled';
-
-			const updatedDoc = { ...result };
-			updatedDoc['status'] = JobStatus.PENDING;
-			updatedDoc['failCount'] = 0;
-			updatedDoc['nextRunAt'] = now;
-			updatedDoc['updatedAt'] = now;
-			delete updatedDoc['failReason'];
-			delete updatedDoc['lockedAt'];
-			delete updatedDoc['claimedBy'];
-			delete updatedDoc['lastHeartbeat'];
-
-			const job = this.ctx.documentToPersistedJob(updatedDoc);
-			this.ctx.notifyPendingJob(job.name, job.nextRunAt);
-			this.ctx.emit('job:retried', { job, previousStatus });
-			return job;
+			this.ctx.emit('job:retried', retried);
+			return retried.job;
 		} catch (error) {
 			if (error instanceof MonqueError) {
 				throw error;
@@ -187,38 +120,8 @@ export class JobManager {
 	 * ```
 	 */
 	async rescheduleJob(jobId: string, runAt: Date): Promise<PersistedJob<unknown> | null> {
-		if (!ObjectId.isValid(jobId)) return null;
-
-		const _id = new ObjectId(jobId);
-
 		try {
-			const now = new Date();
-			const result = await this.ctx.collection.findOneAndUpdate(
-				{ _id, status: JobStatus.PENDING },
-				{
-					$set: {
-						nextRunAt: runAt,
-						updatedAt: now,
-					},
-				},
-				{ returnDocument: 'after' },
-			);
-
-			if (!result) {
-				const currentJobDoc = await this.ctx.collection.findOne({ _id });
-				if (!currentJobDoc) return null;
-
-				throw new JobStateError(
-					`Cannot reschedule job in status '${currentJobDoc['status']}'`,
-					jobId,
-					currentJobDoc['status'],
-					'reschedule',
-				);
-			}
-
-			const job = this.ctx.documentToPersistedJob(result);
-			this.ctx.notifyPendingJob(job.name, job.nextRunAt);
-			return job;
+			return await this.transitions.reschedulePending(jobId, runAt);
 		} catch (error) {
 			if (error instanceof MonqueError) {
 				throw error;
@@ -361,19 +264,17 @@ export class JobManager {
 		const query = buildSelectorQuery(filter);
 
 		// Enforce allowed statuses, but respect explicit status filters
-		const retryable = [JobStatus.FAILED, JobStatus.CANCELLED] as const;
 		if (filter.status !== undefined) {
 			const requested = Array.isArray(filter.status) ? filter.status : [filter.status];
-			const allowed = requested.filter(
-				(status): status is (typeof retryable)[number] =>
-					status === JobStatus.FAILED || status === JobStatus.CANCELLED,
+			const allowed = requested.filter((status): status is RetryableJobStatusType =>
+				RETRYABLE_JOB_STATUSES.includes(status as RetryableJobStatusType),
 			);
 			if (allowed.length === 0) {
 				return { count: 0, errors: [] };
 			}
 			query['status'] = allowed.length === 1 ? allowed[0] : { $in: allowed };
 		} else {
-			query['status'] = { $in: retryable };
+			query['status'] = { $in: RETRYABLE_JOB_STATUSES };
 		}
 
 		const spreadWindowMs = 30_000; // 30s max spread for staggered retry

--- a/packages/core/src/scheduler/services/job-manager.ts
+++ b/packages/core/src/scheduler/services/job-manager.ts
@@ -29,12 +29,13 @@ export class JobManager {
 	/**
 	 * Cancel a pending or scheduled job.
 	 *
-	 * Sets the job status to 'cancelled' and emits a 'job:cancelled' event.
-	 * If the job is already cancelled, this is a no-op and returns the job.
+	 * Uses `transitions.cancelPending()` to set the job status to 'cancelled'.
+	 * Cancellation is idempotent: no-op cancels may return null.
+	 * Emits a 'job:cancelled' event only when a real transition occurs.
 	 * Cannot cancel jobs that are currently 'processing', 'completed', or 'failed'.
 	 *
 	 * @param jobId - The ID of the job to cancel
-	 * @returns The cancelled job, or null if not found
+	 * @returns The cancelled job, or null if not found or cancellation is a no-op
 	 * @throws {JobStateError} If job is in an invalid state for cancellation
 	 *
 	 * @example Cancel a pending job

--- a/packages/core/src/scheduler/services/job-processor.ts
+++ b/packages/core/src/scheduler/services/job-processor.ts
@@ -153,8 +153,8 @@ export class JobProcessor {
 							} else {
 								try {
 									await this.transitions.releaseOwnedClaim(job);
-								} catch (error) {
-									this.ctx.emit('job:error', { error: toError(error) });
+								} catch {
+									// Best-effort shutdown cleanup.
 								}
 							}
 						})

--- a/packages/core/src/scheduler/services/job-processor.ts
+++ b/packages/core/src/scheduler/services/job-processor.ts
@@ -1,8 +1,9 @@
-import { isPersistedJob, type Job, JobStatus, type PersistedJob } from '@/jobs';
-import { calculateBackoff, getNextCronDate, toError } from '@/shared';
+import { type Job, JobStatus, type PersistedJob } from '@/jobs';
+import { toError } from '@/shared';
 import type { WorkerRegistration } from '@/workers';
 
 import { JobSelection } from './job-selection.js';
+import { JobStateTransitions } from './job-state-transitions.js';
 import type { SchedulerContext } from './types.js';
 
 /**
@@ -30,9 +31,11 @@ export class JobProcessor {
 	private _totalActiveJobs = 0;
 
 	private readonly selection: JobSelection;
+	private readonly transitions: JobStateTransitions;
 
 	constructor(private readonly ctx: SchedulerContext) {
 		this.selection = new JobSelection(ctx);
+		this.transitions = new JobStateTransitions(ctx);
 	}
 
 	/**
@@ -148,22 +151,8 @@ export class JobProcessor {
 									this.ctx.emit('job:error', { error: toError(error), job });
 								});
 							} else {
-								// Revert claim if shut down while acquiring
 								try {
-									await this.ctx.collection.updateOne(
-										{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
-										{
-											$set: {
-												status: JobStatus.PENDING,
-												updatedAt: new Date(),
-											},
-											$unset: {
-												lockedAt: '',
-												claimedBy: '',
-												lastHeartbeat: '',
-											},
-										},
-									);
+									await this.transitions.releaseOwnedClaim(job);
 								} catch (error) {
 									this.ctx.emit('job:error', { error: toError(error) });
 								}
@@ -252,67 +241,7 @@ export class JobProcessor {
 	 * @returns The updated job document, or `null` if the transition could not be applied
 	 */
 	async completeJob(job: Job): Promise<PersistedJob | null> {
-		if (!isPersistedJob(job)) {
-			return null;
-		}
-
-		const now = new Date();
-
-		if (job.repeatInterval) {
-			// Recurring job - schedule next run
-			const nextRunAt = getNextCronDate(job.repeatInterval);
-			const result = await this.ctx.collection.findOneAndUpdate(
-				{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
-				{
-					$set: {
-						status: JobStatus.PENDING,
-						nextRunAt,
-						failCount: 0,
-						updatedAt: now,
-					},
-					$unset: {
-						lockedAt: '',
-						claimedBy: '',
-						lastHeartbeat: '',
-						failReason: '',
-					},
-				},
-				{ returnDocument: 'after' },
-			);
-
-			if (!result) {
-				return null;
-			}
-
-			const persistedJob = this.ctx.documentToPersistedJob(result);
-			this.ctx.notifyPendingJob(persistedJob.name, persistedJob.nextRunAt);
-			return persistedJob;
-		}
-
-		// One-time job - mark as completed
-		const result = await this.ctx.collection.findOneAndUpdate(
-			{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
-			{
-				$set: {
-					status: JobStatus.COMPLETED,
-					updatedAt: now,
-				},
-				$unset: {
-					lockedAt: '',
-					claimedBy: '',
-					lastHeartbeat: '',
-					failReason: '',
-				},
-			},
-			{ returnDocument: 'after' },
-		);
-
-		if (!result) {
-			return null;
-		}
-
-		const persistedJob = this.ctx.documentToPersistedJob(result);
-		return persistedJob;
+		return this.transitions.completeOwned(job);
 	}
 
 	/**
@@ -334,63 +263,7 @@ export class JobProcessor {
 	 * @returns The updated job document, or `null` if the transition could not be applied
 	 */
 	async failJob(job: Job, error: Error): Promise<PersistedJob | null> {
-		if (!isPersistedJob(job)) {
-			return null;
-		}
-
-		const now = new Date();
-		const newFailCount = job.failCount + 1;
-
-		if (newFailCount >= this.ctx.options.maxRetries) {
-			// Permanent failure
-			const result = await this.ctx.collection.findOneAndUpdate(
-				{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
-				{
-					$set: {
-						status: JobStatus.FAILED,
-						failCount: newFailCount,
-						failReason: error.message,
-						updatedAt: now,
-					},
-					$unset: {
-						lockedAt: '',
-						claimedBy: '',
-						lastHeartbeat: '',
-					},
-				},
-				{ returnDocument: 'after' },
-			);
-
-			return result ? this.ctx.documentToPersistedJob(result) : null;
-		}
-
-		// Schedule retry with exponential backoff
-		const nextRunAt = calculateBackoff(
-			newFailCount,
-			this.ctx.options.baseRetryInterval,
-			this.ctx.options.maxBackoffDelay,
-		);
-
-		const result = await this.ctx.collection.findOneAndUpdate(
-			{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
-			{
-				$set: {
-					status: JobStatus.PENDING,
-					failCount: newFailCount,
-					failReason: error.message,
-					nextRunAt,
-					updatedAt: now,
-				},
-				$unset: {
-					lockedAt: '',
-					claimedBy: '',
-					lastHeartbeat: '',
-				},
-			},
-			{ returnDocument: 'after' },
-		);
-
-		return result ? this.ctx.documentToPersistedJob(result) : null;
+		return this.transitions.failOwned(job, error);
 	}
 
 	/**

--- a/packages/core/src/scheduler/services/job-state-transitions.ts
+++ b/packages/core/src/scheduler/services/job-state-transitions.ts
@@ -1,0 +1,289 @@
+import { ObjectId } from 'mongodb';
+
+import { isPersistedJob, type Job, JobStatus, type PersistedJob } from '@/jobs';
+import { calculateBackoff, getNextCronDate, JobStateError } from '@/shared';
+
+import {
+	type CancelledJob,
+	RETRYABLE_JOB_STATUSES,
+	type RetriedJob,
+	type RetryableJobStatusType,
+	type SchedulerContext,
+} from './types.js';
+
+/**
+ * Internal module for atomic job lifecycle transitions.
+ *
+ * Keeps status preconditions, ownership checks, claim cleanup, retry scheduling,
+ * and pending-job notification local to one implementation.
+ *
+ * @internal Not part of public API.
+ */
+export class JobStateTransitions {
+	constructor(private readonly ctx: SchedulerContext) {}
+
+	async releaseOwnedClaim(job: PersistedJob): Promise<void> {
+		await this.ctx.collection.updateOne(
+			{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
+			{
+				$set: {
+					status: JobStatus.PENDING,
+					updatedAt: new Date(),
+				},
+				$unset: {
+					lockedAt: '',
+					claimedBy: '',
+					lastHeartbeat: '',
+				},
+			},
+		);
+	}
+
+	async completeOwned(job: Job): Promise<PersistedJob | null> {
+		if (!isPersistedJob(job)) {
+			return null;
+		}
+
+		const now = new Date();
+
+		if (job.repeatInterval) {
+			const nextRunAt = getNextCronDate(job.repeatInterval);
+			const result = await this.ctx.collection.findOneAndUpdate(
+				{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
+				{
+					$set: {
+						status: JobStatus.PENDING,
+						nextRunAt,
+						failCount: 0,
+						updatedAt: now,
+					},
+					$unset: {
+						lockedAt: '',
+						claimedBy: '',
+						lastHeartbeat: '',
+						failReason: '',
+					},
+				},
+				{ returnDocument: 'after' },
+			);
+
+			if (!result) {
+				return null;
+			}
+
+			const persistedJob = this.ctx.documentToPersistedJob(result);
+			this.ctx.notifyPendingJob(persistedJob.name, persistedJob.nextRunAt);
+			return persistedJob;
+		}
+
+		const result = await this.ctx.collection.findOneAndUpdate(
+			{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
+			{
+				$set: {
+					status: JobStatus.COMPLETED,
+					updatedAt: now,
+				},
+				$unset: {
+					lockedAt: '',
+					claimedBy: '',
+					lastHeartbeat: '',
+					failReason: '',
+				},
+			},
+			{ returnDocument: 'after' },
+		);
+
+		return result ? this.ctx.documentToPersistedJob(result) : null;
+	}
+
+	async failOwned(job: Job, error: Error): Promise<PersistedJob | null> {
+		if (!isPersistedJob(job)) {
+			return null;
+		}
+
+		const now = new Date();
+		const newFailCount = job.failCount + 1;
+
+		if (newFailCount >= this.ctx.options.maxRetries) {
+			const result = await this.ctx.collection.findOneAndUpdate(
+				{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
+				{
+					$set: {
+						status: JobStatus.FAILED,
+						failCount: newFailCount,
+						failReason: error.message,
+						updatedAt: now,
+					},
+					$unset: {
+						lockedAt: '',
+						claimedBy: '',
+						lastHeartbeat: '',
+					},
+				},
+				{ returnDocument: 'after' },
+			);
+
+			return result ? this.ctx.documentToPersistedJob(result) : null;
+		}
+
+		const nextRunAt = calculateBackoff(
+			newFailCount,
+			this.ctx.options.baseRetryInterval,
+			this.ctx.options.maxBackoffDelay,
+		);
+
+		const result = await this.ctx.collection.findOneAndUpdate(
+			{ _id: job._id, status: JobStatus.PROCESSING, claimedBy: this.ctx.instanceId },
+			{
+				$set: {
+					status: JobStatus.PENDING,
+					failCount: newFailCount,
+					failReason: error.message,
+					nextRunAt,
+					updatedAt: now,
+				},
+				$unset: {
+					lockedAt: '',
+					claimedBy: '',
+					lastHeartbeat: '',
+				},
+			},
+			{ returnDocument: 'after' },
+		);
+
+		return result ? this.ctx.documentToPersistedJob(result) : null;
+	}
+
+	async cancelPending(jobId: string): Promise<CancelledJob | null> {
+		if (!ObjectId.isValid(jobId)) {
+			return null;
+		}
+
+		const _id = new ObjectId(jobId);
+		const result = await this.ctx.collection.findOneAndUpdate(
+			{ _id, status: JobStatus.PENDING },
+			{
+				$set: {
+					status: JobStatus.CANCELLED,
+					updatedAt: new Date(),
+				},
+			},
+			{ returnDocument: 'after' },
+		);
+
+		if (result) {
+			return { job: this.ctx.documentToPersistedJob(result), transitioned: true };
+		}
+
+		const jobDoc = await this.ctx.collection.findOne({ _id });
+		if (!jobDoc) {
+			return null;
+		}
+
+		if (jobDoc['status'] === JobStatus.CANCELLED) {
+			return { job: this.ctx.documentToPersistedJob(jobDoc), transitioned: false };
+		}
+
+		throw new JobStateError(
+			`Cannot cancel job in status '${jobDoc['status']}'`,
+			jobId,
+			jobDoc['status'],
+			'cancel',
+		);
+	}
+
+	async retryTerminal(jobId: string): Promise<RetriedJob | null> {
+		if (!ObjectId.isValid(jobId)) {
+			return null;
+		}
+
+		const _id = new ObjectId(jobId);
+		const now = new Date();
+		const result = await this.ctx.collection.findOneAndUpdate(
+			{
+				_id,
+				status: { $in: RETRYABLE_JOB_STATUSES },
+			},
+			{
+				$set: {
+					status: JobStatus.PENDING,
+					failCount: 0,
+					nextRunAt: now,
+					updatedAt: now,
+				},
+				$unset: {
+					failReason: '',
+					lockedAt: '',
+					claimedBy: '',
+					lastHeartbeat: '',
+				},
+			},
+			{ returnDocument: 'before' },
+		);
+
+		if (!result) {
+			const currentJob = await this.ctx.collection.findOne({ _id });
+			if (!currentJob) {
+				return null;
+			}
+
+			throw new JobStateError(
+				`Cannot retry job in status '${currentJob['status']}'`,
+				jobId,
+				currentJob['status'],
+				'retry',
+			);
+		}
+
+		const previousStatus = result['status'] as RetryableJobStatusType;
+		const updatedDoc = { ...result };
+		updatedDoc['status'] = JobStatus.PENDING;
+		updatedDoc['failCount'] = 0;
+		updatedDoc['nextRunAt'] = now;
+		updatedDoc['updatedAt'] = now;
+		delete updatedDoc['failReason'];
+		delete updatedDoc['lockedAt'];
+		delete updatedDoc['claimedBy'];
+		delete updatedDoc['lastHeartbeat'];
+
+		const job = this.ctx.documentToPersistedJob(updatedDoc);
+		this.ctx.notifyPendingJob(job.name, job.nextRunAt);
+		return { job, previousStatus };
+	}
+
+	async reschedulePending(jobId: string, runAt: Date): Promise<PersistedJob<unknown> | null> {
+		if (!ObjectId.isValid(jobId)) {
+			return null;
+		}
+
+		const _id = new ObjectId(jobId);
+		const result = await this.ctx.collection.findOneAndUpdate(
+			{ _id, status: JobStatus.PENDING },
+			{
+				$set: {
+					nextRunAt: runAt,
+					updatedAt: new Date(),
+				},
+			},
+			{ returnDocument: 'after' },
+		);
+
+		if (result) {
+			const job = this.ctx.documentToPersistedJob(result);
+			this.ctx.notifyPendingJob(job.name, job.nextRunAt);
+			return job;
+		}
+
+		const currentJobDoc = await this.ctx.collection.findOne({ _id });
+		if (!currentJobDoc) {
+			return null;
+		}
+
+		throw new JobStateError(
+			`Cannot reschedule job in status '${currentJobDoc['status']}'`,
+			jobId,
+			currentJobDoc['status'],
+			'reschedule',
+		);
+	}
+}

--- a/packages/core/src/scheduler/services/types.ts
+++ b/packages/core/src/scheduler/services/types.ts
@@ -1,7 +1,7 @@
 import type { Collection, Document, WithId } from 'mongodb';
 
 import type { MonqueEventMap } from '@/events';
-import type { PersistedJob } from '@/jobs';
+import { JobStatus, type PersistedJob } from '@/jobs';
 import type { WorkerRegistration } from '@/workers';
 
 import type { MonqueOptions } from '../types.js';
@@ -68,4 +68,18 @@ export interface SchedulerContext {
 
 	/** Convert MongoDB document to typed PersistedJob */
 	documentToPersistedJob: <T>(doc: WithId<Document>) => PersistedJob<T>;
+}
+
+export const RETRYABLE_JOB_STATUSES = [JobStatus.FAILED, JobStatus.CANCELLED] as const;
+
+export type RetryableJobStatusType = (typeof RETRYABLE_JOB_STATUSES)[number];
+
+export interface CancelledJob {
+	job: PersistedJob<unknown>;
+	transitioned: boolean;
+}
+
+export interface RetriedJob {
+	job: PersistedJob<unknown>;
+	previousStatus: RetryableJobStatusType;
 }

--- a/packages/core/tests/integration/events.test.ts
+++ b/packages/core/tests/integration/events.test.ts
@@ -220,6 +220,24 @@ describe('Monitor Job Lifecycle Events', () => {
 			expect(event.job._id?.toString()).toBe(job._id.toString());
 			expect(event.job.status).toBe(JobStatus.CANCELLED);
 		});
+
+		it('should not emit job:cancelled when cancelling an already cancelled job', async () => {
+			collectionName = uniqueCollectionName(TEST_CONSTANTS.COLLECTION_NAME);
+			monque = new Monque(db, { collectionName });
+			monqueInstances.push(monque);
+			await monque.initialize();
+
+			const cancelledEvents: MonqueEventMap['job:cancelled'][] = [];
+			monque.on('job:cancelled', (payload) => {
+				cancelledEvents.push(payload);
+			});
+
+			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { data: 'cancel-me-once' });
+			await monque.cancelJob(job._id.toString());
+			await monque.cancelJob(job._id.toString());
+
+			expect(cancelledEvents).toHaveLength(1);
+		});
 	});
 
 	describe('job:retried event', () => {

--- a/packages/core/tests/unit/services/job-manager.test.ts
+++ b/packages/core/tests/unit/services/job-manager.test.ts
@@ -70,6 +70,9 @@ describe('JobManager', () => {
 
 			expect(job?.status).toBe(JobStatus.CANCELLED);
 			expect(ctx.mockCollection.findOneAndUpdate).toHaveBeenCalled();
+			expect(ctx.emitHistory).not.toContainEqual(
+				expect.objectContaining({ event: 'job:cancelled' }),
+			);
 		});
 	});
 

--- a/packages/core/tests/unit/services/job-state-transitions.test.ts
+++ b/packages/core/tests/unit/services/job-state-transitions.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockContext, JobFactoryHelpers } from '@tests/factories';
+import { JobStateTransitions } from '@/scheduler/services/job-state-transitions.js';
+
+describe('JobStateTransitions', () => {
+	let ctx: ReturnType<typeof createMockContext>;
+	let transitions: JobStateTransitions;
+
+	beforeEach(() => {
+		ctx = createMockContext();
+		transitions = new JobStateTransitions(ctx);
+	});
+
+	describe('completeOwned', () => {
+		it('should return null and skip notification when recurring completion loses ownership', async () => {
+			const job = JobFactoryHelpers.processing({
+				repeatInterval: '0 * * * *',
+			});
+
+			vi.spyOn(ctx.mockCollection, 'findOneAndUpdate').mockResolvedValueOnce(null);
+
+			const result = await transitions.completeOwned(job);
+
+			expect(result).toBeNull();
+			expect(ctx.notifyPendingJob).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('job id validation', () => {
+		it('should return null without querying for invalid cancel ids', async () => {
+			const result = await transitions.cancelPending('not-an-object-id');
+
+			expect(result).toBeNull();
+			expect(ctx.mockCollection.findOneAndUpdate).not.toHaveBeenCalled();
+			expect(ctx.mockCollection.findOne).not.toHaveBeenCalled();
+		});
+
+		it('should return null without querying for invalid retry ids', async () => {
+			const result = await transitions.retryTerminal('not-an-object-id');
+
+			expect(result).toBeNull();
+			expect(ctx.mockCollection.findOneAndUpdate).not.toHaveBeenCalled();
+			expect(ctx.mockCollection.findOne).not.toHaveBeenCalled();
+		});
+
+		it('should return null without querying for invalid reschedule ids', async () => {
+			const result = await transitions.reschedulePending('not-an-object-id', new Date());
+
+			expect(result).toBeNull();
+			expect(ctx.mockCollection.findOneAndUpdate).not.toHaveBeenCalled();
+			expect(ctx.mockCollection.findOne).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
- return job as no-op for already-cancelled IDs
- only emit lifecycle event when status transitions from pending to cancelled
- add unit + integration regression coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The `job:cancelled` event is now emitted only when a job transitions from `pending` to `cancelled`, preventing duplicate events when cancelling an already-cancelled job.
  * `cancelJob()` is now fully idempotent, with no observable side effects on repeated calls.

* **Documentation**
  * Added comprehensive documentation clarifying job cancellation semantics and job lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->