### PR TITLE
Add bulk job actions to @monque/management

### DIFF
--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -8,17 +8,20 @@ export {
 	ManagementRoutePath,
 } from './routes/index.js';
 export {
+	BulkActionResultSchema,
 	CapabilitiesSchema,
 	DeleteJobSchema,
 	ErrorSchema,
 	JobCursorPageSchema,
 	JobSchema,
+	JobSelectorSchema,
 	QueueStatsSchema,
 	QueueViewSummaryListSchema,
 	RescheduleJobRequestSchema,
 	SchedulerHealthSchema,
 } from './schemas/index.js';
 export type {
+	BulkActionResultDto,
 	CapabilitiesDto,
 	CapabilityActionsDto,
 	DeleteJobDto,

--- a/packages/management/src/openapi/openapi.ts
+++ b/packages/management/src/openapi/openapi.ts
@@ -10,11 +10,13 @@ import { OpenApiBuilder } from 'openapi3-ts/oas31';
 import { HttpMethod, OpenApiResponseStatus } from '../http/index.js';
 import { MANAGEMENT_ROUTE_MAP } from '../routes/index.js';
 import {
+	BulkActionResultSchema,
 	CapabilitiesSchema,
 	DeleteJobSchema,
 	ErrorSchema,
 	JobCursorPageSchema,
 	JobSchema,
+	JobSelectorSchema,
 	QueueStatsSchema,
 	QueueViewSummaryListSchema,
 	RescheduleJobRequestSchema,
@@ -36,6 +38,8 @@ export function getManagementOpenApiDocument(): OpenAPIObject {
 		JobSchema,
 		JobCursorPageSchema,
 		DeleteJobSchema,
+		BulkActionResultSchema,
+		JobSelectorSchema,
 		RescheduleJobRequestSchema,
 		ErrorSchema,
 	]) {

--- a/packages/management/src/routes/route-map.ts
+++ b/packages/management/src/routes/route-map.ts
@@ -2,11 +2,13 @@ import { Type } from '@sinclair/typebox';
 
 import { HttpMethod, HttpStatus } from '../http/index.js';
 import {
+	BulkActionResultSchema,
 	CapabilitiesSchema,
 	DeleteJobSchema,
 	ErrorSchema,
 	JobCursorPageSchema,
 	JobSchema,
+	JobSelectorSchema,
 	QueueStatsSchema,
 	QueueViewSummaryListSchema,
 	RescheduleJobRequestSchema,
@@ -24,6 +26,9 @@ export const ManagementRoutePath = {
 	JOB_CANCEL: '/api/v1/jobs/{id}/actions/cancel',
 	JOB_RETRY: '/api/v1/jobs/{id}/actions/retry',
 	JOB_RESCHEDULE: '/api/v1/jobs/{id}/actions/reschedule',
+	JOBS_BULK_CANCEL: '/api/v1/jobs/actions/cancel',
+	JOBS_BULK_RETRY: '/api/v1/jobs/actions/retry',
+	JOBS_BULK_DELETE: '/api/v1/jobs/actions/delete',
 } as const;
 
 export type ManagementRoutePathType =
@@ -192,6 +197,48 @@ export const MANAGEMENT_ROUTE_MAP = [
 				required: true,
 				schema: Type.String(),
 			},
+		],
+	},
+	{
+		method: HttpMethod.POST,
+		path: ManagementRoutePath.JOBS_BULK_CANCEL,
+		operationId: 'cancelJobs',
+		requestSchema: JobSelectorSchema,
+		responseSchema: BulkActionResultSchema,
+		errorSchema: ErrorSchema,
+		errorStatuses: [
+			HttpStatus.BAD_REQUEST,
+			HttpStatus.FORBIDDEN,
+			HttpStatus.CONFLICT,
+			HttpStatus.INTERNAL_SERVER_ERROR,
+		],
+	},
+	{
+		method: HttpMethod.POST,
+		path: ManagementRoutePath.JOBS_BULK_RETRY,
+		operationId: 'retryJobs',
+		requestSchema: JobSelectorSchema,
+		responseSchema: BulkActionResultSchema,
+		errorSchema: ErrorSchema,
+		errorStatuses: [
+			HttpStatus.BAD_REQUEST,
+			HttpStatus.FORBIDDEN,
+			HttpStatus.CONFLICT,
+			HttpStatus.INTERNAL_SERVER_ERROR,
+		],
+	},
+	{
+		method: HttpMethod.POST,
+		path: ManagementRoutePath.JOBS_BULK_DELETE,
+		operationId: 'deleteJobs',
+		requestSchema: JobSelectorSchema,
+		responseSchema: BulkActionResultSchema,
+		errorSchema: ErrorSchema,
+		errorStatuses: [
+			HttpStatus.BAD_REQUEST,
+			HttpStatus.FORBIDDEN,
+			HttpStatus.CONFLICT,
+			HttpStatus.INTERNAL_SERVER_ERROR,
 		],
 	},
 	{

--- a/packages/management/src/schemas/dtos.ts
+++ b/packages/management/src/schemas/dtos.ts
@@ -35,7 +35,9 @@ const JobStatusSchema = Type.Union([
 export const JobSelectorSchema = Type.Object(
 	{
 		name: Type.Optional(Type.String()),
-		status: Type.Optional(Type.Union([JobStatusSchema, Type.Array(JobStatusSchema)])),
+		status: Type.Optional(
+			Type.Union([JobStatusSchema, Type.Array(JobStatusSchema, { minItems: 1 })]),
+		),
 		olderThan: Type.Optional(Type.String({ format: 'date-time' })),
 		newerThan: Type.Optional(Type.String({ format: 'date-time' })),
 	},

--- a/packages/management/src/schemas/dtos.ts
+++ b/packages/management/src/schemas/dtos.ts
@@ -24,6 +24,37 @@ export const CapabilitiesSchema = Type.Object(
 	{ $id: 'Capabilities' },
 );
 
+const JobStatusSchema = Type.Union([
+	Type.Literal('pending'),
+	Type.Literal('processing'),
+	Type.Literal('completed'),
+	Type.Literal('failed'),
+	Type.Literal('cancelled'),
+]);
+
+export const JobSelectorSchema = Type.Object(
+	{
+		name: Type.Optional(Type.String()),
+		status: Type.Optional(Type.Union([JobStatusSchema, Type.Array(JobStatusSchema)])),
+		olderThan: Type.Optional(Type.String({ format: 'date-time' })),
+		newerThan: Type.Optional(Type.String({ format: 'date-time' })),
+	},
+	{ $id: 'JobSelector' },
+);
+
+export const BulkActionResultSchema = Type.Object(
+	{
+		count: Type.Number(),
+		errors: Type.Array(
+			Type.Object({
+				jobId: Type.String(),
+				error: Type.String(),
+			}),
+		),
+	},
+	{ $id: 'BulkActionResult' },
+);
+
 export const QueueStatsSchema = Type.Object(
 	{
 		pending: Type.Number(),
@@ -64,13 +95,7 @@ export const JobSchema = Type.Object(
 	{
 		id: Type.String(),
 		name: Type.String(),
-		status: Type.Union([
-			Type.Literal('pending'),
-			Type.Literal('processing'),
-			Type.Literal('completed'),
-			Type.Literal('failed'),
-			Type.Literal('cancelled'),
-		]),
+		status: JobStatusSchema,
 		payload: Type.Unknown(),
 		nextRunAt: Type.String({ format: 'date-time' }),
 		lockedAt: Type.Union([Type.String({ format: 'date-time' }), Type.Null()]),

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -1,9 +1,11 @@
 export {
+	BulkActionResultSchema,
 	CapabilitiesSchema,
 	DeleteJobSchema,
 	ErrorSchema,
 	JobCursorPageSchema,
 	JobSchema,
+	JobSelectorSchema,
 	QueueStatsSchema,
 	QueueViewSummaryListSchema,
 	RescheduleJobRequestSchema,

--- a/packages/management/src/surface/index.ts
+++ b/packages/management/src/surface/index.ts
@@ -1,5 +1,6 @@
 export { createManagementSurface } from './surface.js';
 export type {
+	BulkActionResultDto,
 	CapabilitiesDto,
 	CapabilityActionsDto,
 	DeleteJobDto,

--- a/packages/management/src/surface/surface.ts
+++ b/packages/management/src/surface/surface.ts
@@ -1,7 +1,9 @@
 import {
+	type BulkOperationResult,
 	type CursorOptions,
 	InvalidCursorError,
 	isValidJobStatus,
+	type JobSelector,
 	JobStateError,
 	type JobStatusType,
 	type PersistedJob,
@@ -42,31 +44,59 @@ const ACTION_METHOD_BY_ACTION = {
 	reschedule: 'rescheduleJob',
 	delete: 'deleteJob',
 } as const satisfies Record<WritableAction, keyof ManagementMonque>;
+const BULK_ACTION_METHOD_BY_ACTION = {
+	cancel: 'cancelJobs',
+	retry: 'retryJobs',
+	delete: 'deleteJobs',
+} as const satisfies Record<Exclude<WritableAction, 'reschedule'>, keyof ManagementMonque>;
 const ACTION_ROUTES = [
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOB_CANCEL,
 		action: 'cancel',
+		methodName: 'cancelJob',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOB_RETRY,
 		action: 'retry',
+		methodName: 'retryJob',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOB_RESCHEDULE,
 		action: 'reschedule',
+		methodName: 'rescheduleJob',
 	},
 	{
 		method: HttpMethod.DELETE,
 		path: ManagementRoutePath.JOB_DETAIL,
 		action: 'delete',
+		methodName: 'deleteJob',
+	},
+	{
+		method: HttpMethod.POST,
+		path: ManagementRoutePath.JOBS_BULK_CANCEL,
+		action: 'cancel',
+		methodName: 'cancelJobs',
+	},
+	{
+		method: HttpMethod.POST,
+		path: ManagementRoutePath.JOBS_BULK_RETRY,
+		action: 'retry',
+		methodName: 'retryJobs',
+	},
+	{
+		method: HttpMethod.POST,
+		path: ManagementRoutePath.JOBS_BULK_DELETE,
+		action: 'delete',
+		methodName: 'deleteJobs',
 	},
 ] as const satisfies ReadonlyArray<{
 	method: ManagementRoute['method'];
 	path: ManagementRoute['path'];
 	action: WritableAction;
+	methodName: keyof ManagementMonque;
 }>;
 const ISO_DATE_TIME_PATTERN =
 	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
@@ -192,6 +222,42 @@ export function createManagementSurface<TContext = unknown>(
 
 				if (
 					request.method === HttpMethod.POST &&
+					request.path === ManagementRoutePath.JOBS_BULK_CANCEL
+				) {
+					return await handleBulkJobMutation(
+						options,
+						request,
+						'cancel',
+						options.monque.cancelJobs?.bind(options.monque),
+					);
+				}
+
+				if (
+					request.method === HttpMethod.POST &&
+					request.path === ManagementRoutePath.JOBS_BULK_RETRY
+				) {
+					return await handleBulkJobMutation(
+						options,
+						request,
+						'retry',
+						options.monque.retryJobs?.bind(options.monque),
+					);
+				}
+
+				if (
+					request.method === HttpMethod.POST &&
+					request.path === ManagementRoutePath.JOBS_BULK_DELETE
+				) {
+					return await handleBulkJobMutation(
+						options,
+						request,
+						'delete',
+						options.monque.deleteJobs?.bind(options.monque),
+					);
+				}
+
+				if (
+					request.method === HttpMethod.POST &&
 					request.path === ManagementRoutePath.JOB_RESCHEDULE
 				) {
 					const body = parseRescheduleBody(request.body);
@@ -305,6 +371,116 @@ function parseRescheduleBody(body: unknown): { nextRunAt: Date } | { error: stri
 	return { nextRunAt: date };
 }
 
+function parseJobSelector(body: unknown): JobSelector | { error: string } {
+	if (!body || typeof body !== 'object' || Array.isArray(body)) {
+		return { error: 'Invalid job selector' };
+	}
+
+	const input = body as Record<string, unknown>;
+	const selector: JobSelector = {};
+	const name = input['name'];
+	const status = input['status'];
+	const olderThan = input['olderThan'];
+	const newerThan = input['newerThan'];
+
+	if (name !== undefined) {
+		if (typeof name !== 'string') {
+			return { error: 'Invalid selector name' };
+		}
+
+		selector.name = name;
+	}
+
+	const statuses = parseSelectorStatuses(status);
+
+	if ('error' in statuses) {
+		return statuses;
+	}
+
+	if (statuses.status !== undefined) {
+		selector.status = statuses.status;
+	}
+
+	const olderThanDate = parseOptionalIsoDateTime(olderThan, 'olderThan');
+
+	if ('error' in olderThanDate) {
+		return olderThanDate;
+	}
+
+	if (olderThanDate.value !== undefined) {
+		selector.olderThan = olderThanDate.value;
+	}
+
+	const newerThanDate = parseOptionalIsoDateTime(newerThan, 'newerThan');
+
+	if ('error' in newerThanDate) {
+		return newerThanDate;
+	}
+
+	if (newerThanDate.value !== undefined) {
+		selector.newerThan = newerThanDate.value;
+	}
+
+	return selector;
+}
+
+function parseSelectorStatuses(
+	value: unknown,
+): { status: JobStatusType | JobStatusType[] | undefined } | { error: string } {
+	if (value === undefined) {
+		return { status: undefined };
+	}
+
+	if (typeof value === 'string') {
+		if (!isValidJobStatus(value)) {
+			return { error: 'Invalid status' };
+		}
+
+		return { status: value };
+	}
+
+	if (!Array.isArray(value) || value.length === 0) {
+		return { error: 'Invalid status' };
+	}
+
+	const statuses: JobStatusType[] = [];
+
+	for (const status of value) {
+		if (typeof status !== 'string' || !isValidJobStatus(status)) {
+			return { error: 'Invalid status' };
+		}
+
+		statuses.push(status);
+	}
+
+	return { status: statuses };
+}
+
+function parseOptionalIsoDateTime(
+	value: unknown,
+	fieldName: 'olderThan' | 'newerThan',
+): { value: Date | undefined } | { error: string } {
+	if (value === undefined) {
+		return { value: undefined };
+	}
+
+	if (typeof value !== 'string') {
+		return { error: `Invalid ${fieldName}` };
+	}
+
+	if (!isValidIsoDateTime(value)) {
+		return { error: `Invalid ${fieldName}` };
+	}
+
+	const date = new Date(value);
+
+	if (Number.isNaN(date.getTime())) {
+		return { error: `Invalid ${fieldName}` };
+	}
+
+	return { value: date };
+}
+
 function isValidIsoDateTime(value: string): boolean {
 	const match = ISO_DATE_TIME_PATTERN.exec(value);
 
@@ -385,6 +561,25 @@ async function handleDeleteJobAction<TContext>(
 	}
 
 	return ok({ deleted: true as const });
+}
+
+async function handleBulkJobMutation<TContext>(
+	options: ManagementOptions<TContext>,
+	request: ManagementRequest<TContext>,
+	action: Exclude<WritableAction, 'reschedule'>,
+	mutate: ((selector: JobSelector) => Promise<BulkOperationResult>) | undefined,
+): Promise<ManagementResponse> {
+	const target = await requireBulkJobTarget(options, request, action);
+
+	if ('status' in target) {
+		return target;
+	}
+
+	if (!mutate) {
+		return unsupportedAction();
+	}
+
+	return ok(await mutate(target.selector));
 }
 
 async function getJobs<TContext>(
@@ -518,10 +713,14 @@ function parseLimit(value: ManagementQueryValue): { limit: number } | { error: s
 }
 
 function parseStatuses(
-	value: ManagementQueryValue,
+	value: ManagementQueryValue | unknown,
 ): { status: JobStatusType | JobStatusType[] | undefined } | { error: string } {
 	if (value === undefined) {
 		return { status: undefined };
+	}
+
+	if (typeof value !== 'string' && !Array.isArray(value)) {
+		return { error: 'Invalid status' };
 	}
 
 	const statuses = Array.isArray(value) ? value : [value];
@@ -601,7 +800,7 @@ async function requireMutableJobTarget<TContext>(
 		return writeAuthorization;
 	}
 
-	if (!isActionSupported(options.monque, action)) {
+	if (!isSingleActionSupported(options.monque, action)) {
 		return unsupportedAction();
 	}
 
@@ -632,6 +831,54 @@ async function requireActionAuthorization<TContext>(
 	job: PersistedJob,
 ): Promise<ManagementResponse<{ error: string }> | undefined> {
 	if (await isAllowedByAuthorization(options, action, context, job)) {
+		return undefined;
+	}
+
+	return forbidden('Action denied');
+}
+
+async function requireBulkJobTarget<TContext>(
+	options: ManagementOptions<TContext>,
+	request: ManagementRequest<TContext>,
+	action: Exclude<WritableAction, 'reschedule'>,
+): Promise<{ selector: JobSelector } | ManagementResponse<{ error: string }>> {
+	const writeAuthorization = requireWritableAction(options);
+
+	if (writeAuthorization) {
+		return writeAuthorization;
+	}
+
+	if (!isBulkActionSupported(options.monque, action)) {
+		return unsupportedAction();
+	}
+
+	const selector = parseJobSelector(request.body);
+
+	if ('error' in selector) {
+		return badRequest(selector.error);
+	}
+
+	const actionAuthorization = await requireBulkActionAuthorization(
+		options,
+		action,
+		request.context,
+		selector,
+	);
+
+	if (actionAuthorization) {
+		return actionAuthorization;
+	}
+
+	return { selector };
+}
+
+async function requireBulkActionAuthorization<TContext>(
+	options: ManagementOptions<TContext>,
+	action: Exclude<WritableAction, 'reschedule'>,
+	context: TContext,
+	selector: JobSelector,
+): Promise<ManagementResponse<{ error: string }> | undefined> {
+	if (await isAllowedByAuthorization(options, action, context, undefined, selector)) {
 		return undefined;
 	}
 
@@ -682,7 +929,7 @@ function isRouteSupported(monque: ManagementMonque, route: ManagementRoute): boo
 		(candidate) => candidate.method === route.method && candidate.path === route.path,
 	);
 
-	return actionRoute ? isActionSupported(monque, actionRoute.action) : true;
+	return actionRoute ? monque[actionRoute.methodName] !== undefined : true;
 }
 
 function isActionSupported(monque: ManagementMonque, action: ManagementAction): boolean {
@@ -690,7 +937,21 @@ function isActionSupported(monque: ManagementMonque, action: ManagementAction): 
 		return true;
 	}
 
+	return (
+		isSingleActionSupported(monque, action) ||
+		(action !== 'reschedule' && monque[BULK_ACTION_METHOD_BY_ACTION[action]] !== undefined)
+	);
+}
+
+function isSingleActionSupported(monque: ManagementMonque, action: WritableAction): boolean {
 	return monque[ACTION_METHOD_BY_ACTION[action]] !== undefined;
+}
+
+function isBulkActionSupported(
+	monque: ManagementMonque,
+	action: Exclude<WritableAction, 'reschedule'>,
+): boolean {
+	return monque[BULK_ACTION_METHOD_BY_ACTION[action]] !== undefined;
 }
 
 async function isAllowedByAuthorization<TContext>(
@@ -698,10 +959,11 @@ async function isAllowedByAuthorization<TContext>(
 	action: ManagementAction,
 	context: TContext,
 	job?: PersistedJob,
+	selector?: JobSelector,
 ): Promise<boolean> {
 	if (!options.authorize) {
 		return true;
 	}
 
-	return options.authorize({ action, context, job });
+	return options.authorize({ action, context, job, selector });
 }

--- a/packages/management/src/surface/surface.ts
+++ b/packages/management/src/surface/surface.ts
@@ -108,6 +108,7 @@ const DEFAULT_CAPABILITY_ACTIONS = {
 	reschedule: false,
 	delete: false,
 } satisfies CapabilityActionsDto & Record<(typeof ACTIONS)[number], boolean>;
+const JOB_SELECTOR_FIELDS = ['name', 'status', 'olderThan', 'newerThan'] as const;
 
 export function createManagementSurface<TContext = unknown>(
 	options: ManagementOptions<TContext>,
@@ -260,6 +261,12 @@ export function createManagementSurface<TContext = unknown>(
 					request.method === HttpMethod.POST &&
 					request.path === ManagementRoutePath.JOB_RESCHEDULE
 				) {
+					const writeAuthorization = requireWritableAction(options);
+
+					if (writeAuthorization) {
+						return writeAuthorization;
+					}
+
 					const body = parseRescheduleBody(request.body);
 
 					if ('error' in body) {
@@ -382,6 +389,12 @@ function parseJobSelector(body: unknown): JobSelector | { error: string } {
 	const status = input['status'];
 	const olderThan = input['olderThan'];
 	const newerThan = input['newerThan'];
+
+	for (const key of Object.keys(input)) {
+		if (!JOB_SELECTOR_FIELDS.some((field) => field === key)) {
+			return { error: 'Invalid job selector' };
+		}
+	}
 
 	if (name !== undefined) {
 		if (typeof name !== 'string') {
@@ -788,16 +801,16 @@ async function requireMutableJobTarget<TContext>(
 	request: ManagementRequest<TContext>,
 	action: WritableAction,
 ): Promise<{ id: ObjectId } | ManagementResponse<{ error: string }>> {
-	const id = parseObjectId(request.params?.['id']);
-
-	if ('error' in id) {
-		return badRequest(id.error);
-	}
-
 	const writeAuthorization = requireWritableAction(options);
 
 	if (writeAuthorization) {
 		return writeAuthorization;
+	}
+
+	const id = parseObjectId(request.params?.['id']);
+
+	if ('error' in id) {
+		return badRequest(id.error);
 	}
 
 	if (!isSingleActionSupported(options.monque, action)) {

--- a/packages/management/src/surface/surface.ts
+++ b/packages/management/src/surface/surface.ts
@@ -37,6 +37,7 @@ const WRITABLE_ACTIONS = [
 ] as const satisfies readonly ManagementAction[];
 
 type WritableAction = (typeof WRITABLE_ACTIONS)[number];
+
 const ACTIONS = ['read', ...WRITABLE_ACTIONS] as const satisfies readonly ManagementAction[];
 const ACTION_METHOD_BY_ACTION = {
 	cancel: 'cancelJob',
@@ -44,60 +45,72 @@ const ACTION_METHOD_BY_ACTION = {
 	reschedule: 'rescheduleJob',
 	delete: 'deleteJob',
 } as const satisfies Record<WritableAction, keyof ManagementMonque>;
+
 const BULK_ACTION_METHOD_BY_ACTION = {
 	cancel: 'cancelJobs',
 	retry: 'retryJobs',
 	delete: 'deleteJobs',
 } as const satisfies Record<Exclude<WritableAction, 'reschedule'>, keyof ManagementMonque>;
+
+type SingleActionRoute = {
+	method: ManagementRoute['method'];
+	path: ManagementRoute['path'];
+	action: WritableAction;
+	kind: 'single';
+};
+
+type BulkActionRoute = {
+	method: ManagementRoute['method'];
+	path: ManagementRoute['path'];
+	action: Exclude<WritableAction, 'reschedule'>;
+	kind: 'bulk';
+};
+
 const ACTION_ROUTES = [
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOB_CANCEL,
 		action: 'cancel',
-		methodName: 'cancelJob',
+		kind: 'single',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOB_RETRY,
 		action: 'retry',
-		methodName: 'retryJob',
+		kind: 'single',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOB_RESCHEDULE,
 		action: 'reschedule',
-		methodName: 'rescheduleJob',
+		kind: 'single',
 	},
 	{
 		method: HttpMethod.DELETE,
 		path: ManagementRoutePath.JOB_DETAIL,
 		action: 'delete',
-		methodName: 'deleteJob',
+		kind: 'single',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOBS_BULK_CANCEL,
 		action: 'cancel',
-		methodName: 'cancelJobs',
+		kind: 'bulk',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOBS_BULK_RETRY,
 		action: 'retry',
-		methodName: 'retryJobs',
+		kind: 'bulk',
 	},
 	{
 		method: HttpMethod.POST,
 		path: ManagementRoutePath.JOBS_BULK_DELETE,
 		action: 'delete',
-		methodName: 'deleteJobs',
+		kind: 'bulk',
 	},
-] as const satisfies ReadonlyArray<{
-	method: ManagementRoute['method'];
-	path: ManagementRoute['path'];
-	action: WritableAction;
-	methodName: keyof ManagementMonque;
-}>;
+] as const satisfies ReadonlyArray<SingleActionRoute | BulkActionRoute>;
+
 const ISO_DATE_TIME_PATTERN =
 	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
 
@@ -108,6 +121,7 @@ const DEFAULT_CAPABILITY_ACTIONS = {
 	reschedule: false,
 	delete: false,
 } satisfies CapabilityActionsDto & Record<(typeof ACTIONS)[number], boolean>;
+
 const JOB_SELECTOR_FIELDS = ['name', 'status', 'olderThan', 'newerThan'] as const;
 
 export function createManagementSurface<TContext = unknown>(
@@ -360,22 +374,13 @@ function parseRescheduleBody(body: unknown): { nextRunAt: Date } | { error: stri
 	}
 
 	const nextRunAt = (body as Record<string, unknown>)['nextRunAt'];
+	const parsedNextRunAt = parseIsoDateTime(nextRunAt, 'nextRunAt');
 
-	if (typeof nextRunAt !== 'string') {
-		return { error: 'Invalid nextRunAt' };
+	if ('error' in parsedNextRunAt) {
+		return parsedNextRunAt;
 	}
 
-	if (!isValidIsoDateTime(nextRunAt)) {
-		return { error: 'Invalid nextRunAt' };
-	}
-
-	const date = new Date(nextRunAt);
-
-	if (Number.isNaN(date.getTime())) {
-		return { error: 'Invalid nextRunAt' };
-	}
-
-	return { nextRunAt: date };
+	return { nextRunAt: parsedNextRunAt.value };
 }
 
 function parseJobSelector(body: unknown): JobSelector | { error: string } {
@@ -404,7 +409,7 @@ function parseJobSelector(body: unknown): JobSelector | { error: string } {
 		selector.name = name;
 	}
 
-	const statuses = parseSelectorStatuses(status);
+	const statuses = parseStatuses(status, { preserveArray: true });
 
 	if ('error' in statuses) {
 		return statuses;
@@ -437,8 +442,9 @@ function parseJobSelector(body: unknown): JobSelector | { error: string } {
 	return selector;
 }
 
-function parseSelectorStatuses(
-	value: unknown,
+function parseStatuses(
+	value: ManagementQueryValue | unknown,
+	options: { preserveArray?: boolean } = {},
 ): { status: JobStatusType | JobStatusType[] | undefined } | { error: string } {
 	if (value === undefined) {
 		return { status: undefined };
@@ -466,7 +472,9 @@ function parseSelectorStatuses(
 		statuses.push(status);
 	}
 
-	return { status: statuses };
+	return {
+		status: options.preserveArray === true || statuses.length > 1 ? statuses : statuses[0],
+	};
 }
 
 function parseOptionalIsoDateTime(
@@ -477,6 +485,13 @@ function parseOptionalIsoDateTime(
 		return { value: undefined };
 	}
 
+	return parseIsoDateTime(value, fieldName);
+}
+
+function parseIsoDateTime(
+	value: unknown,
+	fieldName: 'nextRunAt' | 'olderThan' | 'newerThan',
+): { value: Date } | { error: string } {
 	if (typeof value !== 'string') {
 		return { error: `Invalid ${fieldName}` };
 	}
@@ -725,38 +740,6 @@ function parseLimit(value: ManagementQueryValue): { limit: number } | { error: s
 	};
 }
 
-function parseStatuses(
-	value: ManagementQueryValue | unknown,
-): { status: JobStatusType | JobStatusType[] | undefined } | { error: string } {
-	if (value === undefined) {
-		return { status: undefined };
-	}
-
-	if (typeof value !== 'string' && !Array.isArray(value)) {
-		return { error: 'Invalid status' };
-	}
-
-	const statuses = Array.isArray(value) ? value : [value];
-
-	if (statuses.length === 0) {
-		return { error: 'Invalid status' };
-	}
-
-	const validStatuses: JobStatusType[] = [];
-
-	for (const status of statuses) {
-		if (!isValidJobStatus(status)) {
-			return { error: 'Invalid status' };
-		}
-
-		validStatuses.push(status);
-	}
-
-	return {
-		status: validStatuses.length === 1 ? validStatuses[0] : validStatuses,
-	};
-}
-
 function getSingleQueryValue(
 	value: ManagementQueryValue,
 ): { value: string | undefined } | { error: string } {
@@ -942,7 +925,13 @@ function isRouteSupported(monque: ManagementMonque, route: ManagementRoute): boo
 		(candidate) => candidate.method === route.method && candidate.path === route.path,
 	);
 
-	return actionRoute ? monque[actionRoute.methodName] !== undefined : true;
+	if (!actionRoute) {
+		return true;
+	}
+
+	return actionRoute.kind === 'bulk'
+		? isBulkActionSupported(monque, actionRoute.action)
+		: isSingleActionSupported(monque, actionRoute.action);
 }
 
 function isActionSupported(monque: ManagementMonque, action: ManagementAction): boolean {
@@ -950,10 +939,7 @@ function isActionSupported(monque: ManagementMonque, action: ManagementAction): 
 		return true;
 	}
 
-	return (
-		isSingleActionSupported(monque, action) ||
-		(action !== 'reschedule' && monque[BULK_ACTION_METHOD_BY_ACTION[action]] !== undefined)
-	);
+	return isSingleActionSupported(monque, action);
 }
 
 function isSingleActionSupported(monque: ManagementMonque, action: WritableAction): boolean {

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -1,6 +1,8 @@
 import type {
+	BulkOperationResult,
 	CursorOptions,
 	CursorPage,
+	JobSelector,
 	JobStatusType,
 	Monque,
 	PersistedJob,
@@ -25,12 +27,16 @@ export interface ManagementMonque {
 	retryJob?(id: string): Promise<PersistedJob | null>;
 	rescheduleJob?(id: string, runAt: Date): Promise<PersistedJob | null>;
 	deleteJob?(id: string): Promise<boolean>;
+	cancelJobs?(selector: JobSelector): Promise<BulkOperationResult>;
+	retryJobs?(selector: JobSelector): Promise<BulkOperationResult>;
+	deleteJobs?(selector: JobSelector): Promise<BulkOperationResult>;
 }
 
 export interface ManagementAuthorizationInput<TContext = unknown> {
 	action: ManagementAction;
 	context: TContext;
 	job?: PersistedJob | undefined;
+	selector?: JobSelector | undefined;
 }
 
 export type ManagementAuthorize<TContext = unknown> = (
@@ -151,6 +157,8 @@ export interface JobCursorPageDto {
 export interface DeleteJobDto {
 	deleted: true;
 }
+
+export type BulkActionResultDto = BulkOperationResult;
 
 export interface ManagementSurface<TContext = unknown> {
 	readonly routes: readonly ManagementRoute[];

--- a/packages/management/tests/unit/capabilities.test.ts
+++ b/packages/management/tests/unit/capabilities.test.ts
@@ -117,4 +117,69 @@ describe('Management capabilities', () => {
 			body: { error: 'Management action is unsupported' },
 		});
 	});
+
+	test('enables bulk routes when bulk public core methods are available', async () => {
+		const monque: ManagementMonque = {
+			isHealthy: () => true,
+			getQueueViewSummaries: async () => [],
+			getJobsWithCursor: async () => ({
+				jobs: [],
+				cursor: null,
+				hasNextPage: false,
+				hasPreviousPage: false,
+			}),
+			getJob: async () => null,
+			getQueueStats: async () => ({
+				pending: 0,
+				processing: 0,
+				completed: 0,
+				failed: 0,
+				cancelled: 0,
+				total: 0,
+			}),
+			cancelJobs: async () => ({ count: 0, errors: [] }),
+			retryJobs: async () => ({ count: 0, errors: [] }),
+			deleteJobs: async () => ({ count: 0, errors: [] }),
+		};
+		const surface = createManagementSurface({ monque });
+
+		const response = await surface.handle({
+			method: HttpMethod.GET,
+			path: ManagementRoutePath.CAPABILITIES,
+			context: {},
+		});
+		const unsupportedSingleCancel = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOB_CANCEL,
+			params: { id: '000000000000000000000000' },
+			context: {},
+		});
+
+		expect(response).toEqual({
+			status: HttpStatus.OK,
+			body: {
+				readOnly: false,
+				actions: {
+					read: true,
+					cancel: true,
+					retry: true,
+					reschedule: false,
+					delete: true,
+				},
+			},
+		});
+		expect(surface.routes.map((route) => `${route.method} ${route.path}`)).toContain(
+			'POST /api/v1/jobs/actions/cancel',
+		);
+		expect(surface.routes.map((route) => `${route.method} ${route.path}`)).toContain(
+			'POST /api/v1/jobs/actions/retry',
+		);
+		expect(surface.routes.map((route) => `${route.method} ${route.path}`)).toContain(
+			'POST /api/v1/jobs/actions/delete',
+		);
+		expect(unsupportedSingleCancel).toEqual({
+			status: HttpStatus.FORBIDDEN,
+			body: { error: 'Management action is unsupported' },
+		});
+	});
 });

--- a/packages/management/tests/unit/capabilities.test.ts
+++ b/packages/management/tests/unit/capabilities.test.ts
@@ -118,7 +118,7 @@ describe('Management capabilities', () => {
 		});
 	});
 
-	test('enables bulk routes when bulk public core methods are available', async () => {
+	test('enables bulk routes without enabling single action capabilities', async () => {
 		const monque: ManagementMonque = {
 			isHealthy: () => true,
 			getQueueViewSummaries: async () => [],
@@ -154,6 +154,7 @@ describe('Management capabilities', () => {
 			params: { id: '000000000000000000000000' },
 			context: {},
 		});
+		const routeIds = surface.routes.map((route) => `${route.method} ${route.path}`);
 
 		expect(response).toEqual({
 			status: HttpStatus.OK,
@@ -161,22 +162,16 @@ describe('Management capabilities', () => {
 				readOnly: false,
 				actions: {
 					read: true,
-					cancel: true,
-					retry: true,
+					cancel: false,
+					retry: false,
 					reschedule: false,
-					delete: true,
+					delete: false,
 				},
 			},
 		});
-		expect(surface.routes.map((route) => `${route.method} ${route.path}`)).toContain(
-			'POST /api/v1/jobs/actions/cancel',
-		);
-		expect(surface.routes.map((route) => `${route.method} ${route.path}`)).toContain(
-			'POST /api/v1/jobs/actions/retry',
-		);
-		expect(surface.routes.map((route) => `${route.method} ${route.path}`)).toContain(
-			'POST /api/v1/jobs/actions/delete',
-		);
+		expect(routeIds).toContain('POST /api/v1/jobs/actions/cancel');
+		expect(routeIds).toContain('POST /api/v1/jobs/actions/retry');
+		expect(routeIds).toContain('POST /api/v1/jobs/actions/delete');
 		expect(unsupportedSingleCancel).toEqual({
 			status: HttpStatus.FORBIDDEN,
 			body: { error: 'Management action is unsupported' },

--- a/packages/management/tests/unit/openapi.test.ts
+++ b/packages/management/tests/unit/openapi.test.ts
@@ -41,18 +41,24 @@ describe('Management OpenAPI contract', () => {
 		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.operationId).toBe('cancelJobs');
 		expect(document.paths?.['/api/v1/jobs/actions/retry']?.post?.operationId).toBe('retryJobs');
 		expect(document.paths?.['/api/v1/jobs/actions/delete']?.post?.operationId).toBe('deleteJobs');
-		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.requestBody).toMatchObject({
-			required: true,
-			content: {
-				'application/json': {
-					schema: { $ref: '#/components/schemas/JobSelector' },
+		for (const path of [
+			'/api/v1/jobs/actions/cancel',
+			'/api/v1/jobs/actions/retry',
+			'/api/v1/jobs/actions/delete',
+		] as const) {
+			expect(document.paths?.[path]?.post?.requestBody).toMatchObject({
+				required: true,
+				content: {
+					'application/json': {
+						schema: { $ref: '#/components/schemas/JobSelector' },
+					},
 				},
-			},
-		});
-		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('400');
-		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('403');
-		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('409');
-		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('500');
+			});
+			expect(document.paths?.[path]?.post?.responses).toHaveProperty('400');
+			expect(document.paths?.[path]?.post?.responses).toHaveProperty('403');
+			expect(document.paths?.[path]?.post?.responses).toHaveProperty('409');
+			expect(document.paths?.[path]?.post?.responses).toHaveProperty('500');
+		}
 		expect(
 			document.paths?.['/api/v1/jobs/{id}/actions/reschedule']?.post?.requestBody,
 		).toMatchObject({

--- a/packages/management/tests/unit/openapi.test.ts
+++ b/packages/management/tests/unit/openapi.test.ts
@@ -38,6 +38,21 @@ describe('Management OpenAPI contract', () => {
 		expect(document.paths?.['/api/v1/jobs/{id}/actions/reschedule']?.post?.operationId).toBe(
 			'rescheduleJob',
 		);
+		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.operationId).toBe('cancelJobs');
+		expect(document.paths?.['/api/v1/jobs/actions/retry']?.post?.operationId).toBe('retryJobs');
+		expect(document.paths?.['/api/v1/jobs/actions/delete']?.post?.operationId).toBe('deleteJobs');
+		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.requestBody).toMatchObject({
+			required: true,
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/JobSelector' },
+				},
+			},
+		});
+		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('400');
+		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('403');
+		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('409');
+		expect(document.paths?.['/api/v1/jobs/actions/cancel']?.post?.responses).toHaveProperty('500');
 		expect(
 			document.paths?.['/api/v1/jobs/{id}/actions/reschedule']?.post?.requestBody,
 		).toMatchObject({
@@ -74,6 +89,19 @@ describe('Management OpenAPI contract', () => {
 		expect(document.components?.schemas?.['DeleteJob']).toMatchObject({
 			type: 'object',
 			required: ['deleted'],
+		});
+		expect(document.components?.schemas?.['BulkActionResult']).toMatchObject({
+			type: 'object',
+			required: ['count', 'errors'],
+		});
+		expect(document.components?.schemas?.['JobSelector']).toMatchObject({
+			type: 'object',
+			properties: expect.objectContaining({
+				name: expect.any(Object),
+				status: expect.any(Object),
+				olderThan: expect.any(Object),
+				newerThan: expect.any(Object),
+			}),
 		});
 		expect(document.components?.schemas?.['RescheduleJobRequest']).toMatchObject({
 			type: 'object',

--- a/packages/management/tests/unit/surface.test.ts
+++ b/packages/management/tests/unit/surface.test.ts
@@ -103,6 +103,37 @@ describe('Management Surface contract', () => {
 		});
 	});
 
+	test('keeps bulk cancel idempotent for repeated empty-result operations', async () => {
+		const calls: unknown[] = [];
+		const monque = createManagementMonque({
+			cancelJobs: async (selector) => {
+				calls.push(selector);
+				return { count: 0, errors: [] };
+			},
+		});
+		const surface = createManagementSurface({ monque });
+		const request = {
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { status: ['pending'] },
+			context: {},
+		};
+
+		const first = await surface.handle(request);
+		const second = await surface.handle(request);
+
+		expect(first).toEqual({
+			status: HttpStatus.OK,
+			body: { count: 0, errors: [] },
+		});
+		expect(second).toEqual({
+			status: HttpStatus.OK,
+			body: { count: 0, errors: [] },
+		});
+		expect(calls).toEqual([{ status: ['pending'] }, { status: ['pending'] }]);
+		expect(calls[0]).toEqual(calls[1]);
+	});
+
 	test('bulk retries and deletes Jobs through public core APIs with stable result DTOs', async () => {
 		const calls: Array<{ action: string; selector: unknown }> = [];
 		const monque = createManagementMonque({

--- a/packages/management/tests/unit/surface.test.ts
+++ b/packages/management/tests/unit/surface.test.ts
@@ -48,6 +48,281 @@ function createManagementMonque(overrides: Partial<ManagementMonque> = {}): Mana
 }
 
 describe('Management Surface contract', () => {
+	test('bulk cancels Jobs through public core API with selector DTO', async () => {
+		const calls: unknown[] = [];
+		const authorizeCalls: unknown[] = [];
+		const monque = createManagementMonque({
+			cancelJobs: async (selector) => {
+				calls.push(selector);
+				return {
+					count: 2,
+					errors: [],
+				};
+			},
+		});
+		const surface = createManagementSurface<{ userId: string }>({
+			monque,
+			authorize: ({ action, context, selector }) => {
+				authorizeCalls.push({ action, context, selector });
+				return true;
+			},
+		});
+
+		const response = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: {
+				name: 'send-email',
+				status: ['pending'],
+				olderThan: '2026-02-01T10:30:00.000Z',
+				newerThan: '2026-01-01T00:00:00.000Z',
+			},
+			context: { userId: 'operator-1' },
+		});
+
+		const expectedSelector = {
+			name: 'send-email',
+			status: ['pending'],
+			olderThan: new Date('2026-02-01T10:30:00.000Z'),
+			newerThan: new Date('2026-01-01T00:00:00.000Z'),
+		};
+		expect(calls).toEqual([expectedSelector]);
+		expect(authorizeCalls).toEqual([
+			{
+				action: 'cancel',
+				context: { userId: 'operator-1' },
+				selector: expectedSelector,
+			},
+		]);
+		expect(response).toEqual({
+			status: HttpStatus.OK,
+			body: {
+				count: 2,
+				errors: [],
+			},
+		});
+	});
+
+	test('bulk retries and deletes Jobs through public core APIs with stable result DTOs', async () => {
+		const calls: Array<{ action: string; selector: unknown }> = [];
+		const monque = createManagementMonque({
+			retryJobs: async (selector) => {
+				calls.push({ action: 'retry', selector });
+				return {
+					count: 1,
+					errors: [{ jobId: 'job-1', error: 'still processing' }],
+				};
+			},
+			deleteJobs: async (selector) => {
+				calls.push({ action: 'delete', selector });
+				return {
+					count: 3,
+					errors: [],
+				};
+			},
+		});
+		const surface = createManagementSurface({ monque });
+
+		const retry = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_RETRY,
+			body: {
+				status: 'failed',
+			},
+			context: {},
+		});
+		const deleted = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_DELETE,
+			body: {
+				status: ['completed', 'cancelled'],
+			},
+			context: {},
+		});
+
+		expect(calls).toEqual([
+			{ action: 'retry', selector: { status: 'failed' } },
+			{ action: 'delete', selector: { status: ['completed', 'cancelled'] } },
+		]);
+		expect(retry).toEqual({
+			status: HttpStatus.OK,
+			body: {
+				count: 1,
+				errors: [{ jobId: 'job-1', error: 'still processing' }],
+			},
+		});
+		expect(deleted).toEqual({
+			status: HttpStatus.OK,
+			body: {
+				count: 3,
+				errors: [],
+			},
+		});
+	});
+
+	test('rejects invalid bulk selector request shapes before calling core', async () => {
+		const calls: string[] = [];
+		const monque = createManagementMonque({
+			cancelJobs: async () => {
+				calls.push('cancel');
+				return { count: 0, errors: [] };
+			},
+		});
+		const surface = createManagementSurface({ monque });
+
+		const invalidShape = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: [],
+			context: {},
+		});
+		const invalidStatus = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { status: [] },
+			context: {},
+		});
+		const invalidDate = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { olderThan: 'February 1, 2026 10:30:00' },
+			context: {},
+		});
+
+		expect(invalidShape).toEqual({
+			status: HttpStatus.BAD_REQUEST,
+			body: { error: 'Invalid job selector' },
+		});
+		expect(invalidStatus).toEqual({
+			status: HttpStatus.BAD_REQUEST,
+			body: { error: 'Invalid status' },
+		});
+		expect(invalidDate).toEqual({
+			status: HttpStatus.BAD_REQUEST,
+			body: { error: 'Invalid olderThan' },
+		});
+		expect(calls).toEqual([]);
+	});
+
+	test('rejects all bulk Job mutations in read-only mode before calling core actions', async () => {
+		const calls: string[] = [];
+		const monque = createManagementMonque({
+			cancelJobs: async () => {
+				calls.push('cancel');
+				return { count: 0, errors: [] };
+			},
+			retryJobs: async () => {
+				calls.push('retry');
+				return { count: 0, errors: [] };
+			},
+			deleteJobs: async () => {
+				calls.push('delete');
+				return { count: 0, errors: [] };
+			},
+		});
+		const surface = createManagementSurface({ monque, readOnly: true });
+
+		const responses = await Promise.all([
+			surface.handle({
+				method: HttpMethod.POST,
+				path: ManagementRoutePath.JOBS_BULK_CANCEL,
+				body: {},
+				context: {},
+			}),
+			surface.handle({
+				method: HttpMethod.POST,
+				path: ManagementRoutePath.JOBS_BULK_RETRY,
+				body: {},
+				context: {},
+			}),
+			surface.handle({
+				method: HttpMethod.POST,
+				path: ManagementRoutePath.JOBS_BULK_DELETE,
+				body: {},
+				context: {},
+			}),
+		]);
+
+		expect(responses).toEqual([
+			{ status: HttpStatus.FORBIDDEN, body: { error: 'Management surface is read-only' } },
+			{ status: HttpStatus.FORBIDDEN, body: { error: 'Management surface is read-only' } },
+			{ status: HttpStatus.FORBIDDEN, body: { error: 'Management surface is read-only' } },
+		]);
+		expect(calls).toEqual([]);
+	});
+
+	test('authorizes bulk Job mutations with action, context, and selector before core action', async () => {
+		const authorizeCalls: unknown[] = [];
+		const actionCalls: string[] = [];
+		const monque = createManagementMonque({
+			cancelJobs: async () => {
+				actionCalls.push('cancel');
+				return { count: 0, errors: [] };
+			},
+		});
+		const surface = createManagementSurface<{ userId: string }>({
+			monque,
+			authorize: ({ action, context, selector }) => {
+				authorizeCalls.push({ action, context, selector });
+				return false;
+			},
+		});
+
+		const response = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { name: 'send-email' },
+			context: { userId: 'operator-1' },
+		});
+
+		expect(response).toEqual({
+			status: HttpStatus.FORBIDDEN,
+			body: { error: 'Action denied' },
+		});
+		expect(authorizeCalls).toEqual([
+			{
+				action: 'cancel',
+				context: { userId: 'operator-1' },
+				selector: { name: 'send-email' },
+			},
+		]);
+		expect(actionCalls).toEqual([]);
+	});
+
+	test('maps bulk Job action conflicts and core errors', async () => {
+		const monque = createManagementMonque({
+			cancelJobs: async () => {
+				throw new JobStateError('Cannot cancel selected jobs', 'bulk', 'processing', 'cancel');
+			},
+			retryJobs: async () => {
+				throw new ConnectionError('db down');
+			},
+		});
+		const surface = createManagementSurface({ monque });
+
+		const conflict = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { status: 'processing' },
+			context: {},
+		});
+		const unexpected = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_RETRY,
+			body: { status: 'failed' },
+			context: {},
+		});
+
+		expect(conflict).toEqual({
+			status: HttpStatus.CONFLICT,
+			body: { error: 'Cannot cancel selected jobs' },
+		});
+		expect(unexpected).toEqual({
+			status: HttpStatus.INTERNAL_SERVER_ERROR,
+			body: { error: 'Internal server error' },
+		});
+	});
+
 	test('cancels single pending Job through public core API and returns Job DTO', async () => {
 		const jobId = new ObjectId();
 		const calls: string[] = [];

--- a/packages/management/tests/unit/surface.test.ts
+++ b/packages/management/tests/unit/surface.test.ts
@@ -188,6 +188,18 @@ describe('Management Surface contract', () => {
 			body: { olderThan: 'February 1, 2026 10:30:00' },
 			context: {},
 		});
+		const unknownSelectorField = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { olderThen: '2026-02-01T10:30:00.000Z' },
+			context: {},
+		});
+		const mixedUnknownSelectorField = await surface.handle({
+			method: HttpMethod.POST,
+			path: ManagementRoutePath.JOBS_BULK_CANCEL,
+			body: { name: 'send-email', unexpected: true },
+			context: {},
+		});
 
 		expect(invalidShape).toEqual({
 			status: HttpStatus.BAD_REQUEST,
@@ -200,6 +212,14 @@ describe('Management Surface contract', () => {
 		expect(invalidDate).toEqual({
 			status: HttpStatus.BAD_REQUEST,
 			body: { error: 'Invalid olderThan' },
+		});
+		expect(unknownSelectorField).toEqual({
+			status: HttpStatus.BAD_REQUEST,
+			body: { error: 'Invalid job selector' },
+		});
+		expect(mixedUnknownSelectorField).toEqual({
+			status: HttpStatus.BAD_REQUEST,
+			body: { error: 'Invalid job selector' },
 		});
 		expect(calls).toEqual([]);
 	});
@@ -239,6 +259,54 @@ describe('Management Surface contract', () => {
 				method: HttpMethod.POST,
 				path: ManagementRoutePath.JOBS_BULK_DELETE,
 				body: {},
+				context: {},
+			}),
+		]);
+
+		expect(responses).toEqual([
+			{ status: HttpStatus.FORBIDDEN, body: { error: 'Management surface is read-only' } },
+			{ status: HttpStatus.FORBIDDEN, body: { error: 'Management surface is read-only' } },
+			{ status: HttpStatus.FORBIDDEN, body: { error: 'Management surface is read-only' } },
+		]);
+		expect(calls).toEqual([]);
+	});
+
+	test('rejects malformed single Job mutations as read-only before request validation', async () => {
+		const calls: string[] = [];
+		const monque = createManagementMonque({
+			cancelJob: async () => {
+				calls.push('cancel');
+				return null;
+			},
+			rescheduleJob: async () => {
+				calls.push('reschedule');
+				return null;
+			},
+			deleteJob: async () => {
+				calls.push('delete');
+				return false;
+			},
+		});
+		const surface = createManagementSurface({ monque, readOnly: true });
+
+		const responses = await Promise.all([
+			surface.handle({
+				method: HttpMethod.POST,
+				path: ManagementRoutePath.JOB_CANCEL,
+				params: { id: 'not-an-object-id' },
+				context: {},
+			}),
+			surface.handle({
+				method: HttpMethod.POST,
+				path: ManagementRoutePath.JOB_RESCHEDULE,
+				params: { id: new ObjectId().toHexString() },
+				body: { nextRunAt: 'not-a-date' },
+				context: {},
+			}),
+			surface.handle({
+				method: HttpMethod.DELETE,
+				path: ManagementRoutePath.JOB_DETAIL,
+				params: { id: 'not-an-object-id' },
 				context: {},
 			}),
 		]);


### PR DESCRIPTION
## Summary
- Add the new `@monque/management` package with a framework-neutral management surface for Monque.
- Expose job, queue view, health, capabilities, and mutation endpoints, including bulk `cancel`, `retry`, and `delete` actions.
- Publish shared DTO schemas, route metadata, and an OpenAPI 3.1 document from the package route map.
- Tighten mutation validation and authorization handling for management requests.

## Testing
- `packages/management/tests/unit/capabilities.test.ts`
- `packages/management/tests/unit/openapi.test.ts`
- `packages/management/tests/unit/package-contract.test.ts`
- `packages/management/tests/unit/surface.test.ts`
- Run: full repository `bun run check`
- Run: full repository `bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk job management actions: cancel, retry, and delete multiple jobs in a single operation.
  * Introduced job selection and filtering capabilities for bulk operations.
  * New API endpoints for bulk job management with comprehensive error handling and authorization support.

* **Tests**
  * Added comprehensive test coverage for bulk operations, including authorization and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->