### PR TITLE
feat(management): add oRPC health tracer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,10 +63,15 @@
     },
     "packages/management": {
       "name": "@monque/management",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "dependencies": {
+        "@orpc/contract": "^1.14.2",
+        "@orpc/openapi": "^1.14.2",
+        "@orpc/server": "^1.14.2",
+        "@orpc/zod": "^1.14.2",
         "@sinclair/typebox": "^0.34.49",
         "openapi3-ts": "^4.5.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@monque/core": "workspace:*",
@@ -448,6 +453,36 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@ocavue/utils": ["@ocavue/utils@1.6.0", "", {}, "sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg=="],
+
+    "@orpc/client": ["@orpc/client@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2", "@orpc/standard-server-fetch": "1.14.2", "@orpc/standard-server-peer": "1.14.2" } }, "sha512-/tFAua/w/mao2kQtJqjoCYEojHrKMisxOCK8qtkMKOUcXVxWMl+QWhP/MykjzFgkFdO9mzKOu1h7vJvpH73EBA=="],
+
+    "@orpc/contract": ["@orpc/contract@1.14.2", "", { "dependencies": { "@orpc/client": "1.14.2", "@orpc/shared": "1.14.2", "@standard-schema/spec": "^1.1.0", "openapi-types": "^12.1.3" } }, "sha512-51XFgfUYOfX7thwb8ww2EE0YHJDveW9HQNt7TN6sQMb3Bjx54h9r7vdfPJjUOJP3J4Ri2tOVstOsZ3CWUjbi5A=="],
+
+    "@orpc/interop": ["@orpc/interop@1.14.2", "", {}, "sha512-FkrXlR0vmhx5D0t5WA6YN7XyC1WwjGGmkaaShVUGdnFu6m0bl4v3vZZWIMcPy5fG/6wF7KCTEGx0B6+kMmLWiQ=="],
+
+    "@orpc/json-schema": ["@orpc/json-schema@1.14.2", "", { "dependencies": { "@orpc/contract": "1.14.2", "@orpc/interop": "1.14.2", "@orpc/openapi": "1.14.2", "@orpc/server": "1.14.2", "@orpc/shared": "1.14.2", "json-schema-typed": "^8.0.2" } }, "sha512-CpK8+evqU1j685f5M2UUO+tsm0HFKeykTQNTtq0WGMyFy7PPVOGYbJxZSorLJmWDfEw8ImPP2bj3wXEEOJsgag=="],
+
+    "@orpc/openapi": ["@orpc/openapi@1.14.2", "", { "dependencies": { "@orpc/client": "1.14.2", "@orpc/contract": "1.14.2", "@orpc/interop": "1.14.2", "@orpc/openapi-client": "1.14.2", "@orpc/server": "1.14.2", "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2", "json-schema-typed": "^8.0.2", "rou3": "^0.7.12" } }, "sha512-Xuy8auE1KubDjZGc5mvntSfaHy03p0tjDfEkx7k/S4SSJi0o4Rn+HYgCltgYznKwuyMnljl/0gShf99bo77lFg=="],
+
+    "@orpc/openapi-client": ["@orpc/openapi-client@1.14.2", "", { "dependencies": { "@orpc/client": "1.14.2", "@orpc/contract": "1.14.2", "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2" } }, "sha512-KIXSVuGYh3JvO0lxUUztuMkEj6FV5C96QivR+H/HvqfFidC3hEH0nqi0vEWmUzlbzH3jbCaJV8KKV41HKnUNYw=="],
+
+    "@orpc/server": ["@orpc/server@1.14.2", "", { "dependencies": { "@orpc/client": "1.14.2", "@orpc/contract": "1.14.2", "@orpc/interop": "1.14.2", "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2", "@orpc/standard-server-aws-lambda": "1.14.2", "@orpc/standard-server-fastify": "1.14.2", "@orpc/standard-server-fetch": "1.14.2", "@orpc/standard-server-node": "1.14.2", "@orpc/standard-server-peer": "1.14.2", "cookie": "^1.1.1" }, "peerDependencies": { "crossws": ">=0.3.4", "ws": ">=8.18.1" }, "optionalPeers": ["crossws", "ws"] }, "sha512-+MkYqqI1CmR/eWsktpAxN4+Dd1rbDGO3xh9ZQae/V4zID5uz7smUnsIJL97GRDIZkwRUYlC8TDLLPAkxij22Iw=="],
+
+    "@orpc/shared": ["@orpc/shared@1.14.2", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-5YtbVz4yGbJgcyj7CmEv5FAy4xagCS/hP/MMAlHpJKBSlMHuD7FrDO4LQLFUmSkcBcbLhzX8Ll1ziUw3vtPasw=="],
+
+    "@orpc/standard-server": ["@orpc/standard-server@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2" } }, "sha512-XHySJICwDsJf211gcxtJBpzB1ldZrSHDW2mqbBQg+I2AewvTqWiqeGZV+SPvmq87q4IfBzncSuwMrRKplUJhsw=="],
+
+    "@orpc/standard-server-aws-lambda": ["@orpc/standard-server-aws-lambda@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2", "@orpc/standard-server-fetch": "1.14.2", "@orpc/standard-server-node": "1.14.2" } }, "sha512-/aPEC+WTQMHxmX8NauolIyzTRic96vPM17py3oe7LEaCyP/McyKUVrUsKu4He4zkEFrj3ErwVeOCkm19VvtIMQ=="],
+
+    "@orpc/standard-server-fastify": ["@orpc/standard-server-fastify@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2", "@orpc/standard-server-node": "1.14.2" }, "peerDependencies": { "fastify": ">=5.6.1" }, "optionalPeers": ["fastify"] }, "sha512-qmbNZKU+JdNKqaKHwUBCytx0G1RKYbfBwA5Cqf+S6Y+4InpwEdbcRSMgRnN+VH40lRPQAg1RO0AmH3NtvQ4yNw=="],
+
+    "@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2" } }, "sha512-FPXhHfGPA2Hcb3GBd6YjsbMbgcvb3XJ5aFr6TXmlpS8Qgek4fDM7nK1nZ+GoA5OitsL6B7Z9WoIbu39IiG1FcA=="],
+
+    "@orpc/standard-server-node": ["@orpc/standard-server-node@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2", "@orpc/standard-server-fetch": "1.14.2" } }, "sha512-9b/ffVIo8ZN6xk8hMxFvRxpaNmNMulPH9elaXkOwOdmH8TJnqAK79sKOSbDbmFx+wI0QPyjXOaqGpU9ie7J4uw=="],
+
+    "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.14.2", "", { "dependencies": { "@orpc/shared": "1.14.2", "@orpc/standard-server": "1.14.2" } }, "sha512-uzbgGaxvlZ0IA2lasaLck+yrbR3bKoqJnsZehEdbSm6eWaKln4COvxQJ2PuPow3gA6tklNnGkTfmRmGIHvS/rg=="],
+
+    "@orpc/zod": ["@orpc/zod@1.14.2", "", { "dependencies": { "@orpc/json-schema": "1.14.2", "@orpc/openapi": "1.14.2", "@orpc/shared": "1.14.2", "escape-string-regexp": "^5.0.0", "wildcard-match": "^5.1.4" }, "peerDependencies": { "@orpc/contract": "1.14.2", "@orpc/server": "1.14.2", "zod": ">=3.25.0" } }, "sha512-47FBoaAz5GfHSdtD/ZNmTjorLD9SiD+I008UH2+DKehC4HMh8V1SbsMWCanUOkh1IFPZ1kzKaOOT+g0OAIOUWA=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -1551,6 +1586,8 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
     "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
@@ -1855,6 +1892,8 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
     "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
@@ -1953,6 +1992,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "radash": ["radash@12.1.1", "", {}, "sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA=="],
+
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
@@ -2044,6 +2085,8 @@
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.23.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.3", "@babel/helper-validator-identifier": "8.0.0-rc.3", "@babel/parser": "8.0.0-rc.3", "@babel/types": "8.0.0-rc.3", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.7", "obug": "^2.1.1", "picomatch": "^4.0.4" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0-rc.12", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
@@ -2155,6 +2198,8 @@
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
 
     "tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
@@ -2214,6 +2259,8 @@
     "twoslash": ["twoslash@0.3.8", "", { "dependencies": { "@typescript/vfs": "^1.6.4", "twoslash-protocol": "0.3.8" }, "peerDependencies": { "typescript": "^5.5.0 || ^6.0.0" } }, "sha512-OeDz0kDl8sqPUN3nr7gqcvOs70f5lZsdhKYTX3/SgB9OvdadzzoYJI/4SBXhXV1HG8E9fLc+e17itoRYTxmoig=="],
 
     "twoslash-protocol": ["twoslash-protocol@0.3.8", "", {}, "sha512-HmvAHoiEviK8LqvAQyc9/irkdvwTUiR1fHmNwH/0gq8EHxyBt4PWVPixjEXg6wJu1u6yBrILEWXGK9Kw58/8yQ=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
@@ -2351,6 +2398,8 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wildcard-match": ["wildcard-match@5.1.4", "", {}, "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g=="],
+
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -2373,7 +2422,7 @@
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -2382,6 +2431,8 @@
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
+    "@astrojs/sitemap/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@babel/generator/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
@@ -2451,6 +2502,8 @@
 
     "astro/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
+    "astro/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -2486,6 +2539,8 @@
     "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "knip/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -62,8 +62,13 @@
 		"lint": "biome check ."
 	},
 	"dependencies": {
+		"@orpc/contract": "^1.14.2",
+		"@orpc/openapi": "^1.14.2",
+		"@orpc/server": "^1.14.2",
+		"@orpc/zod": "^1.14.2",
 		"@sinclair/typebox": "^0.34.49",
-		"openapi3-ts": "^4.5.0"
+		"openapi3-ts": "^4.5.0",
+		"zod": "^4.4.3"
 	},
 	"peerDependencies": {
 		"@monque/core": "^1.8.0",

--- a/packages/management/src/dtos/scheduler-health.ts
+++ b/packages/management/src/dtos/scheduler-health.ts
@@ -1,6 +1,6 @@
 import { Type } from '@sinclair/typebox';
 
-import type { SchedulerHealthDto } from '../surface/index.js';
+import type { SchedulerHealthDto } from '../schemas/index.js';
 
 /**
  * TypeBox schema for the scheduler health response.

--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -18,6 +18,7 @@ export {
 export { getManagementOpenApiDocument } from './openapi/index.js';
 export {
 	createManagementRouter,
+	generateManagementOpenApiDocument,
 	type ManagementContract,
 	type ManagementRouter,
 	managementContract,

--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -16,12 +16,19 @@ export {
 	HttpStatus,
 } from './http/index.js';
 export { getManagementOpenApiDocument } from './openapi/index.js';
+export {
+	createManagementRouter,
+	type ManagementContract,
+	type ManagementRouter,
+	managementContract,
+} from './orpc/index.js';
 export { normalizeManagementRequest } from './request/index.js';
 export {
 	findManagementRoute,
 	MANAGEMENT_ROUTE_MAP,
 	ManagementRoutePath,
 } from './routes/index.js';
+export { SchedulerHealthDtoSchema } from './schemas/index.js';
 export type {
 	BulkActionResultDto,
 	CapabilitiesDto,

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -1,0 +1,17 @@
+import { oc } from '@orpc/contract';
+
+import { SchedulerHealthDtoSchema } from '../schemas/index.js';
+
+export const managementContract = {
+	health: oc
+		.route({
+			method: 'GET',
+			path: '/api/v1/health',
+			operationId: 'getSchedulerHealth',
+			successStatus: 200,
+			successDescription: 'Successful response',
+		})
+		.output(SchedulerHealthDtoSchema),
+};
+
+export type ManagementContract = typeof managementContract;

--- a/packages/management/src/orpc/index.ts
+++ b/packages/management/src/orpc/index.ts
@@ -1,0 +1,8 @@
+export {
+	type ManagementContract,
+	managementContract,
+} from './contract.js';
+export {
+	createManagementRouter,
+	type ManagementRouter,
+} from './router.js';

--- a/packages/management/src/orpc/index.ts
+++ b/packages/management/src/orpc/index.ts
@@ -2,6 +2,7 @@ export {
 	type ManagementContract,
 	managementContract,
 } from './contract.js';
+export { generateManagementOpenApiDocument } from './openapi.js';
 export {
 	createManagementRouter,
 	type ManagementRouter,

--- a/packages/management/src/orpc/openapi.ts
+++ b/packages/management/src/orpc/openapi.ts
@@ -1,0 +1,23 @@
+import { type OpenAPI, OpenAPIGenerator } from '@orpc/openapi';
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
+
+import { SchedulerHealthDtoSchema } from '../schemas/index.js';
+import { managementContract } from './contract.js';
+
+export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Document> {
+	const generator = new OpenAPIGenerator({
+		schemaConverters: [new ZodToJsonSchemaConverter()],
+	});
+
+	return generator.generate(managementContract, {
+		info: {
+			title: 'Monque Management API',
+			version: '0.1.0',
+		},
+		commonSchemas: {
+			SchedulerHealth: {
+				schema: SchedulerHealthDtoSchema,
+			},
+		},
+	});
+}

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -1,0 +1,17 @@
+import { implement } from '@orpc/server';
+
+import { toSchedulerHealthDto } from '../dtos/index.js';
+import type { ManagementOptions } from '../surface/index.js';
+import { managementContract } from './contract.js';
+
+const managementImplementer = implement(managementContract);
+
+export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
+	return managementImplementer.router({
+		health: managementImplementer.health.handler(() =>
+			toSchedulerHealthDto(options.monque.isHealthy()),
+		),
+	});
+}
+
+export type ManagementRouter = ReturnType<typeof createManagementRouter>;

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -1,0 +1,4 @@
+export {
+	type SchedulerHealthDto,
+	SchedulerHealthDtoSchema,
+} from './scheduler-health.js';

--- a/packages/management/src/schemas/scheduler-health.ts
+++ b/packages/management/src/schemas/scheduler-health.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const SchedulerHealthDtoSchema = z
+	.object({
+		status: z.union([z.literal('ok'), z.literal('unavailable')]),
+		scheduler: z
+			.object({
+				healthy: z.boolean(),
+			})
+			.strict(),
+	})
+	.strict();
+
+export type SchedulerHealthDto = z.infer<typeof SchedulerHealthDtoSchema>;

--- a/packages/management/src/surface/surface.ts
+++ b/packages/management/src/surface/surface.ts
@@ -1,4 +1,5 @@
 import { InvalidCursorError, JobStateError } from '@monque/core';
+import { OpenAPIHandler } from '@orpc/openapi/fetch';
 
 import {
 	toJobCursorPageDto,
@@ -7,6 +8,7 @@ import {
 	toQueueViewSummaryListDto,
 	toSchedulerHealthDto,
 } from '../dtos/index.js';
+import { createManagementRouter } from '../orpc/index.js';
 import {
 	getSupportedManagementRoutes,
 	isManagementActionAllowedByReadOnlyMode,
@@ -60,7 +62,10 @@ const DEFAULT_CAPABILITY_ACTIONS = {
 export function createManagementSurface<TContext = unknown>(
 	options: ManagementOptions<TContext>,
 ): ManagementSurface<TContext> {
+	const router = createManagementRouter(options);
+
 	return {
+		openApiHandler: new OpenAPIHandler(router),
 		routes: getSupportedManagementRoutes(options.monque),
 		async handle(request: ManagementRequest<TContext>): Promise<ManagementResponse> {
 			try {

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -8,10 +8,13 @@ import type {
 	PersistedJob,
 	QueueStats,
 } from '@monque/core';
+import type { OpenAPIHandler } from '@orpc/openapi/fetch';
 import type { TSchema } from '@sinclair/typebox';
 import type { ObjectId } from 'mongodb';
 
 import type { HttpMethodType, HttpStatusType } from '../http/index.js';
+
+export type { SchedulerHealthDto } from '../schemas/index.js';
 
 /**
  * High-level Management API action categories.
@@ -273,20 +276,6 @@ export interface ManagementRoute {
 }
 
 /**
- * Scheduler health response DTO.
- */
-export interface SchedulerHealthDto {
-	/** Overall Management health status. */
-	status: 'ok' | 'unavailable';
-
-	/** Scheduler-specific health details. */
-	scheduler: {
-		/** Whether the scheduler reports itself healthy. */
-		healthy: boolean;
-	};
-}
-
-/**
  * Capability flags keyed by Management action.
  */
 export type CapabilityActionsDto = Record<ManagementAction, boolean>;
@@ -438,6 +427,9 @@ export type BulkActionResultDto = BulkOperationResult;
 export interface ManagementSurface<TContext = unknown> {
 	/** Routes supported by the supplied scheduler capability contract. */
 	readonly routes: readonly ManagementRoute[];
+
+	/** oRPC OpenAPI handler mounted by framework adapters. */
+	readonly openApiHandler: OpenAPIHandler<Record<never, never>>;
 
 	/** Handle one normalized Management request. */
 	handle(request: ManagementRequest<TContext>): Promise<ManagementResponse>;

--- a/packages/management/tests/unit/orpc-health.test.ts
+++ b/packages/management/tests/unit/orpc-health.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+
+import { createManagementSurface } from '@/index';
+import type { ManagementMonque } from '@/surface';
+
+function createManagementMonque(overrides: Partial<ManagementMonque> = {}): ManagementMonque {
+	return {
+		isHealthy: () => true,
+		getQueueViewSummaries: async () => [],
+		getJobsWithCursor: async () => ({
+			jobs: [],
+			cursor: null,
+			hasNextPage: false,
+			hasPreviousPage: false,
+		}),
+		getJob: async () => null,
+		getQueueStats: async () => ({
+			pending: 0,
+			processing: 0,
+			completed: 0,
+			failed: 0,
+			cancelled: 0,
+			total: 0,
+		}),
+		...overrides,
+	};
+}
+
+describe('oRPC Management health route', () => {
+	test('serves scheduler health through the OpenAPI handler', async () => {
+		const surface = createManagementSurface({
+			monque: createManagementMonque({ isHealthy: () => false }),
+		});
+
+		const result = await surface.openApiHandler.handle(
+			new Request('https://management.example/api/v1/health', { method: 'GET' }),
+		);
+
+		if (!result.matched) {
+			throw new Error('Expected oRPC OpenAPI handler to match health route');
+		}
+
+		expect(result.response.status).toBe(200);
+		expect(await result.response.json()).toEqual({
+			status: 'unavailable',
+			scheduler: {
+				healthy: false,
+			},
+		});
+	});
+});

--- a/packages/management/tests/unit/orpc-openapi.test.ts
+++ b/packages/management/tests/unit/orpc-openapi.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { generateManagementOpenApiDocument } from '@/index';
+
+describe('oRPC Management OpenAPI contract', () => {
+	test('derives the health path and response schema from the oRPC contract', async () => {
+		const document = await generateManagementOpenApiDocument();
+
+		expect(document.openapi).toBe('3.1.1');
+		expect(document.paths?.['/api/v1/health']?.get?.operationId).toBe('getSchedulerHealth');
+		expect(document.paths?.['/api/v1/health']?.get?.responses?.['200']).toMatchObject({
+			description: 'Successful response',
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/SchedulerHealth' },
+				},
+			},
+		});
+		expect(document.components?.schemas?.['SchedulerHealth']).toMatchObject({
+			type: 'object',
+			required: ['status', 'scheduler'],
+			additionalProperties: false,
+		});
+	});
+});

--- a/packages/management/tests/unit/package-contract.test.ts
+++ b/packages/management/tests/unit/package-contract.test.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
@@ -14,16 +14,14 @@ interface PackageJson {
 	devDependencies?: Record<string, string>;
 }
 
-const FORBIDDEN_RUNTIME_PACKAGES = [
-	'express',
-	'connect',
-	'@tsed/core',
-	'@tsed/di',
-	'@nestjs/common',
-	'fastify',
-	'hono',
-	'@hono/node-server',
-	'scalar',
+const EXPECTED_RUNTIME_DEPENDENCIES = [
+	'@orpc/contract',
+	'@orpc/openapi',
+	'@orpc/server',
+	'@orpc/zod',
+	'@sinclair/typebox',
+	'openapi3-ts',
+	'zod',
 ] as const;
 
 const TEST_DIRECTORY = fileURLToPath(new URL('.', import.meta.url));
@@ -31,12 +29,6 @@ const TEST_DIRECTORY = fileURLToPath(new URL('.', import.meta.url));
 describe('@monque/management package contract', () => {
 	test('is publishable, peer-depends on core and mongodb, and avoids framework coupling', async () => {
 		const packageJson = await readPackageJson();
-		const declaredPackages = {
-			...packageJson.dependencies,
-			...packageJson.peerDependencies,
-			...packageJson.devDependencies,
-		};
-		const sourceFiles = await readSourceFiles(join(TEST_DIRECTORY, '../../src'));
 
 		expect(packageJson.name).toBe('@monque/management');
 		expect(packageJson.private).toBeUndefined();
@@ -47,12 +39,16 @@ describe('@monque/management package contract', () => {
 		});
 		expect(packageJson.dependencies?.['@monque/core']).toBeUndefined();
 		expect(packageJson.dependencies?.['mongodb']).toBeUndefined();
-
-		for (const packageName of FORBIDDEN_RUNTIME_PACKAGES) {
-			expect(declaredPackages[packageName]).toBeUndefined();
-			expect(sourceFiles).not.toContain(`from '${packageName}'`);
-			expect(sourceFiles).not.toContain(`from "${packageName}"`);
-		}
+		expect(packageJson.dependencies).toMatchObject({
+			'@orpc/contract': expect.any(String),
+			'@orpc/openapi': expect.any(String),
+			'@orpc/server': expect.any(String),
+			'@orpc/zod': expect.any(String),
+			zod: expect.any(String),
+		});
+		expect(Object.keys(packageJson.dependencies ?? {}).sort()).toEqual([
+			...EXPECTED_RUNTIME_DEPENDENCIES,
+		]);
 	});
 });
 
@@ -61,24 +57,4 @@ async function readPackageJson(): Promise<PackageJson> {
 	const parsed = JSON.parse(raw) as PackageJson;
 
 	return parsed;
-}
-
-async function readSourceFiles(directory: string): Promise<string> {
-	const entries = await readdir(directory, { withFileTypes: true });
-	const contents: string[] = [];
-
-	for (const entry of entries) {
-		const path = join(directory, entry.name);
-
-		if (entry.isDirectory()) {
-			contents.push(await readSourceFiles(path));
-			continue;
-		}
-
-		if (entry.isFile() && entry.name.endsWith('.ts')) {
-			contents.push(await readFile(path, 'utf8'));
-		}
-	}
-
-	return contents.join('\n');
 }


### PR DESCRIPTION
## Summary

Adds the first oRPC/Zod Management Surface tracer for scheduler health.

This PR keeps the existing unreleased Management surface behavior intact while proving the new ADR-0005 route engine path:

- contract-first oRPC route for `GET /api/v1/health`
- factory-bound oRPC router created from `ManagementOptions`
- OpenAPI handler exposed from the Management surface
- Zod v4-derived health DTO schema/type
- oRPC-generated OpenAPI health contract

Closes #435

## Verification

- `bun run test:unit` in `packages/management`
- `bun run check`
