### PR TITLE
feat(management): add oRPC capabilities route

### DIFF
--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -41,6 +41,7 @@ export type {
 	ManagementAuthorizationInput,
 	ManagementAuthorize,
 	ManagementMonque,
+	ManagementOpenApiContext,
 	ManagementOptions,
 	ManagementPayloadSerializationInput,
 	ManagementPayloadSerializer,

--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -29,7 +29,11 @@ export {
 	MANAGEMENT_ROUTE_MAP,
 	ManagementRoutePath,
 } from './routes/index.js';
-export { SchedulerHealthDtoSchema } from './schemas/index.js';
+export {
+	CapabilitiesDtoSchema,
+	CapabilityActionsDtoSchema,
+	SchedulerHealthDtoSchema,
+} from './schemas/index.js';
 export type {
 	BulkActionResultDto,
 	CapabilitiesDto,

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -1,6 +1,6 @@
 import { oc } from '@orpc/contract';
 
-import { SchedulerHealthDtoSchema } from '../schemas/index.js';
+import { CapabilitiesDtoSchema, SchedulerHealthDtoSchema } from '../schemas/index.js';
 
 export const managementContract = {
 	health: oc
@@ -12,6 +12,15 @@ export const managementContract = {
 			successDescription: 'Successful response',
 		})
 		.output(SchedulerHealthDtoSchema),
+	capabilities: oc
+		.route({
+			method: 'GET',
+			path: '/api/v1/capabilities',
+			operationId: 'getCapabilities',
+			successStatus: 200,
+			successDescription: 'Successful response',
+		})
+		.output(CapabilitiesDtoSchema),
 };
 
 export type ManagementContract = typeof managementContract;

--- a/packages/management/src/orpc/openapi.ts
+++ b/packages/management/src/orpc/openapi.ts
@@ -1,7 +1,7 @@
 import { type OpenAPI, OpenAPIGenerator } from '@orpc/openapi';
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 
-import { SchedulerHealthDtoSchema } from '../schemas/index.js';
+import { CapabilitiesDtoSchema, SchedulerHealthDtoSchema } from '../schemas/index.js';
 import { managementContract } from './contract.js';
 
 export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Document> {
@@ -15,6 +15,9 @@ export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Docum
 			version: '0.1.0',
 		},
 		commonSchemas: {
+			Capabilities: {
+				schema: CapabilitiesDtoSchema,
+			},
 			SchedulerHealth: {
 				schema: SchedulerHealthDtoSchema,
 			},

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -1,6 +1,7 @@
 import { implement } from '@orpc/server';
 
 import { toSchedulerHealthDto } from '../dtos/index.js';
+import { getManagementCapabilities } from '../surface/capabilities.js';
 import type { ManagementOptions } from '../surface/index.js';
 import { managementContract } from './contract.js';
 
@@ -10,6 +11,9 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 	return managementImplementer.router({
 		health: managementImplementer.health.handler(() =>
 			toSchedulerHealthDto(options.monque.isHealthy()),
+		),
+		capabilities: managementImplementer.capabilities.handler(() =>
+			getManagementCapabilities(options, undefined as TContext),
 		),
 	});
 }

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -2,18 +2,19 @@ import { implement } from '@orpc/server';
 
 import { toSchedulerHealthDto } from '../dtos/index.js';
 import { getManagementCapabilities } from '../surface/capabilities.js';
-import type { ManagementOptions } from '../surface/index.js';
+import type { ManagementOpenApiContext, ManagementOptions } from '../surface/index.js';
 import { managementContract } from './contract.js';
 
-const managementImplementer = implement(managementContract);
-
 export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
+	const managementImplementer =
+		implement(managementContract).$context<ManagementOpenApiContext<TContext>>();
+
 	return managementImplementer.router({
 		health: managementImplementer.health.handler(() =>
 			toSchedulerHealthDto(options.monque.isHealthy()),
 		),
-		capabilities: managementImplementer.capabilities.handler(() =>
-			getManagementCapabilities(options, undefined as TContext),
+		capabilities: managementImplementer.capabilities.handler(({ context }) =>
+			getManagementCapabilities(options, context.managementContext as TContext),
 		),
 	});
 }

--- a/packages/management/src/schemas/capabilities.ts
+++ b/packages/management/src/schemas/capabilities.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const CapabilityActionsDtoSchema = z
+	.object({
+		read: z.boolean(),
+		cancel: z.boolean(),
+		retry: z.boolean(),
+		reschedule: z.boolean(),
+		delete: z.boolean(),
+	})
+	.strict();
+
+export type CapabilityActionsDto = z.infer<typeof CapabilityActionsDtoSchema>;
+
+export const CapabilitiesDtoSchema = z
+	.object({
+		readOnly: z.boolean(),
+		actions: CapabilityActionsDtoSchema,
+	})
+	.strict();
+
+export type CapabilitiesDto = z.infer<typeof CapabilitiesDtoSchema>;

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -1,4 +1,10 @@
 export {
+	type CapabilitiesDto,
+	CapabilitiesDtoSchema,
+	type CapabilityActionsDto,
+	CapabilityActionsDtoSchema,
+} from './capabilities.js';
+export {
 	type SchedulerHealthDto,
 	SchedulerHealthDtoSchema,
 } from './scheduler-health.js';

--- a/packages/management/src/surface/capabilities.ts
+++ b/packages/management/src/surface/capabilities.ts
@@ -1,0 +1,51 @@
+import {
+	isManagementActionAllowedByReadOnlyMode,
+	isManagementActionSupported,
+	ManagementActions,
+} from '../routes/index.js';
+import type {
+	CapabilitiesDto,
+	CapabilityActionsDto,
+	ManagementAction,
+	ManagementOptions,
+} from './types.js';
+
+const DEFAULT_CAPABILITY_ACTIONS = {
+	read: false,
+	cancel: false,
+	retry: false,
+	reschedule: false,
+	delete: false,
+} satisfies CapabilityActionsDto & Record<(typeof ManagementActions)[number], boolean>;
+
+export async function getManagementCapabilities<TContext>(
+	options: ManagementOptions<TContext>,
+	context: TContext,
+): Promise<CapabilitiesDto> {
+	const readOnly = options.readOnly ?? false;
+	const actions: CapabilityActionsDto = { ...DEFAULT_CAPABILITY_ACTIONS };
+
+	for (const action of ManagementActions) {
+		actions[action] =
+			isManagementActionSupported(options.monque, action) &&
+			isManagementActionAllowedByReadOnlyMode(action, readOnly) &&
+			(await isAllowedByAuthorization(options, action, context));
+	}
+
+	return {
+		readOnly,
+		actions,
+	};
+}
+
+async function isAllowedByAuthorization<TContext>(
+	options: ManagementOptions<TContext>,
+	action: ManagementAction,
+	context: TContext,
+): Promise<boolean> {
+	if (!options.authorize) {
+		return true;
+	}
+
+	return options.authorize({ action, context });
+}

--- a/packages/management/src/surface/index.ts
+++ b/packages/management/src/surface/index.ts
@@ -11,6 +11,7 @@ export type {
 	ManagementAuthorize,
 	ManagementHttpMethod,
 	ManagementMonque,
+	ManagementOpenApiContext,
 	ManagementOptions,
 	ManagementPayloadSerializationInput,
 	ManagementPayloadSerializer,

--- a/packages/management/src/surface/surface.ts
+++ b/packages/management/src/surface/surface.ts
@@ -9,13 +9,9 @@ import {
 	toSchedulerHealthDto,
 } from '../dtos/index.js';
 import { createManagementRouter } from '../orpc/index.js';
-import {
-	getSupportedManagementRoutes,
-	isManagementActionAllowedByReadOnlyMode,
-	isManagementActionSupported,
-	ManagementActions,
-} from '../routes/index.js';
+import { getSupportedManagementRoutes } from '../routes/index.js';
 import { getSingleQueryValue, parseJobListQuery, parseObjectId } from '../validation/index.js';
+import { getManagementCapabilities } from './capabilities.js';
 import {
 	handleBulkJobMutation,
 	handleDeleteJobAction,
@@ -25,22 +21,12 @@ import {
 import { badRequest, conflict, forbidden, internalServerError, notFound, ok } from './responses.js';
 import { routeManagementRequest } from './route-request.js';
 import type {
-	CapabilitiesDto,
-	CapabilityActionsDto,
 	ManagementAction,
 	ManagementOptions,
 	ManagementRequest,
 	ManagementResponse,
 	ManagementSurface,
 } from './types.js';
-
-const DEFAULT_CAPABILITY_ACTIONS = {
-	read: false,
-	cancel: false,
-	retry: false,
-	reschedule: false,
-	delete: false,
-} satisfies CapabilityActionsDto & Record<(typeof ManagementActions)[number], boolean>;
 
 /**
  * Create a framework-neutral Management API surface for a Monque scheduler.
@@ -81,7 +67,7 @@ export function createManagementSurface<TContext = unknown>(
 					case 'getSchedulerHealth':
 						return ok(toSchedulerHealthDto(options.monque.isHealthy()));
 					case 'getCapabilities':
-						return ok(await getCapabilities(options, managementRequest.context));
+						return ok(await getManagementCapabilities(options, managementRequest.context));
 					case 'listQueueViews': {
 						const readAuthorization = await requireReadAuthorization(
 							options,
@@ -236,26 +222,6 @@ async function requireReadAuthorization<TContext>(
 	}
 
 	return forbidden('Read access denied');
-}
-
-async function getCapabilities<TContext>(
-	options: ManagementOptions<TContext>,
-	context: TContext,
-): Promise<CapabilitiesDto> {
-	const readOnly = options.readOnly ?? false;
-	const actions: CapabilityActionsDto = { ...DEFAULT_CAPABILITY_ACTIONS };
-
-	for (const action of ManagementActions) {
-		actions[action] =
-			isManagementActionSupported(options.monque, action) &&
-			isManagementActionAllowedByReadOnlyMode(action, readOnly) &&
-			(await isAllowedByAuthorization(options, action, context));
-	}
-
-	return {
-		readOnly,
-		actions,
-	};
 }
 
 async function isAllowedByAuthorization<TContext>(

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -186,6 +186,16 @@ export interface ManagementOptions<TContext = unknown> {
 }
 
 /**
+ * Context object supplied to the oRPC OpenAPI handler.
+ *
+ * oRPC requires an object-shaped context, while Management keeps the adapter
+ * request context generic.
+ */
+export type ManagementOpenApiContext<TContext = unknown> = Record<PropertyKey, unknown> & {
+	managementContext?: TContext;
+};
+
+/**
  * Query-string value shape accepted from framework adapters.
  */
 export type ManagementQueryValue = string | readonly string[] | undefined;
@@ -417,7 +427,7 @@ export interface ManagementSurface<TContext = unknown> {
 	readonly routes: readonly ManagementRoute[];
 
 	/** oRPC OpenAPI handler mounted by framework adapters. */
-	readonly openApiHandler: OpenAPIHandler<Record<never, never>>;
+	readonly openApiHandler: OpenAPIHandler<ManagementOpenApiContext<TContext>>;
 
 	/** Handle one normalized Management request. */
 	handle(request: ManagementRequest<TContext>): Promise<ManagementResponse>;

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -14,7 +14,11 @@ import type { ObjectId } from 'mongodb';
 
 import type { HttpMethodType, HttpStatusType } from '../http/index.js';
 
-export type { SchedulerHealthDto } from '../schemas/index.js';
+export type {
+	CapabilitiesDto,
+	CapabilityActionsDto,
+	SchedulerHealthDto,
+} from '../schemas/index.js';
 
 /**
  * High-level Management API action categories.
@@ -273,22 +277,6 @@ export interface ManagementRoute {
 
 	/** Explicit non-200 error statuses documented for this route. */
 	errorStatuses?: readonly HttpStatusType[];
-}
-
-/**
- * Capability flags keyed by Management action.
- */
-export type CapabilityActionsDto = Record<ManagementAction, boolean>;
-
-/**
- * Capabilities response DTO.
- */
-export interface CapabilitiesDto {
-	/** Whether the surface rejects write actions. */
-	readOnly: boolean;
-
-	/** Available actions after scheduler support and read-only mode are applied. */
-	actions: CapabilityActionsDto;
 }
 
 /**

--- a/packages/management/tests/unit/orpc-capabilities.test.ts
+++ b/packages/management/tests/unit/orpc-capabilities.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { createManagementSurface } from '@/index';
-import type { ManagementMonque } from '@/surface';
+import type { ManagementMonque, ManagementOpenApiContext, ManagementSurface } from '@/surface';
 
 function createManagementMonque(overrides: Partial<ManagementMonque> = {}): ManagementMonque {
 	return {
@@ -33,9 +33,10 @@ function createManagementMonque(overrides: Partial<ManagementMonque> = {}): Mana
 	};
 }
 
-async function handleCapabilities(surface: ReturnType<typeof createManagementSurface>) {
+async function handleCapabilities(surface: ManagementSurface, context?: ManagementOpenApiContext) {
 	const result = await surface.openApiHandler.handle(
 		new Request('https://management.example/api/v1/capabilities', { method: 'GET' }),
+		context === undefined ? {} : { context },
 	);
 
 	if (!result.matched) {
@@ -62,6 +63,33 @@ describe('oRPC Management capabilities route', () => {
 				retry: true,
 				reschedule: true,
 				delete: true,
+			},
+		});
+	});
+
+	test('uses adapter-provided request context for action authorization', async () => {
+		const authorizedActions = new Set(['read', 'retry']);
+		const surface = createManagementSurface<{ role: string }>({
+			monque: createManagementMonque(),
+			authorize: ({ action, context }) => {
+				expect(context).toEqual({ role: 'viewer' });
+				return authorizedActions.has(action);
+			},
+		});
+
+		const response = await handleCapabilities(surface, {
+			managementContext: { role: 'viewer' },
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			readOnly: false,
+			actions: {
+				read: true,
+				cancel: false,
+				retry: true,
+				reschedule: false,
+				delete: false,
 			},
 		});
 	});

--- a/packages/management/tests/unit/orpc-capabilities.test.ts
+++ b/packages/management/tests/unit/orpc-capabilities.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, test } from 'vitest';
 import { createManagementSurface } from '@/index';
 import type { ManagementMonque, ManagementOpenApiContext, ManagementSurface } from '@/surface';
 
-function createManagementMonque(overrides: Partial<ManagementMonque> = {}): ManagementMonque {
-	return {
+function createManagementMonque(
+	overrides: Partial<ManagementMonque> = {},
+	options: { mutations?: boolean } = { mutations: true },
+): ManagementMonque {
+	const monque: ManagementMonque = {
 		isHealthy: () => true,
 		getQueueViewSummaries: async () => [],
 		getJobsWithCursor: async () => ({
@@ -22,15 +25,20 @@ function createManagementMonque(overrides: Partial<ManagementMonque> = {}): Mana
 			cancelled: 0,
 			total: 0,
 		}),
-		cancelJob: async () => null,
-		retryJob: async () => null,
-		rescheduleJob: async () => null,
-		deleteJob: async () => false,
-		cancelJobs: async () => ({ count: 0, errors: [] }),
-		retryJobs: async () => ({ count: 0, errors: [] }),
-		deleteJobs: async () => ({ count: 0, errors: [] }),
 		...overrides,
 	};
+
+	if (options.mutations ?? true) {
+		monque.cancelJob = async () => null;
+		monque.retryJob = async () => null;
+		monque.rescheduleJob = async () => null;
+		monque.deleteJob = async () => false;
+		monque.cancelJobs = async () => ({ count: 0, errors: [] });
+		monque.retryJobs = async () => ({ count: 0, errors: [] });
+		monque.deleteJobs = async () => ({ count: 0, errors: [] });
+	}
+
+	return monque;
 }
 
 async function handleCapabilities(surface: ManagementSurface, context?: ManagementOpenApiContext) {
@@ -80,6 +88,53 @@ describe('oRPC Management capabilities route', () => {
 		const response = await handleCapabilities(surface, {
 			managementContext: { role: 'viewer' },
 		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			readOnly: false,
+			actions: {
+				read: true,
+				cancel: false,
+				retry: true,
+				reschedule: false,
+				delete: false,
+			},
+		});
+	});
+
+	test('reports writable actions unavailable in read-only mode', async () => {
+		const surface = createManagementSurface({
+			monque: createManagementMonque(),
+			readOnly: true,
+		});
+
+		const response = await handleCapabilities(surface);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			readOnly: true,
+			actions: {
+				read: true,
+				cancel: false,
+				retry: false,
+				reschedule: false,
+				delete: false,
+			},
+		});
+	});
+
+	test('keeps unsupported actions visible as unavailable capabilities', async () => {
+		const surface = createManagementSurface({
+			monque: createManagementMonque(
+				{
+					retryJob: async () => null,
+					retryJobs: async () => ({ count: 0, errors: [] }),
+				},
+				{ mutations: false },
+			),
+		});
+
+		const response = await handleCapabilities(surface);
 
 		expect(response.status).toBe(200);
 		expect(await response.json()).toEqual({

--- a/packages/management/tests/unit/orpc-capabilities.test.ts
+++ b/packages/management/tests/unit/orpc-capabilities.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+
+import { createManagementSurface } from '@/index';
+import type { ManagementMonque } from '@/surface';
+
+function createManagementMonque(overrides: Partial<ManagementMonque> = {}): ManagementMonque {
+	return {
+		isHealthy: () => true,
+		getQueueViewSummaries: async () => [],
+		getJobsWithCursor: async () => ({
+			jobs: [],
+			cursor: null,
+			hasNextPage: false,
+			hasPreviousPage: false,
+		}),
+		getJob: async () => null,
+		getQueueStats: async () => ({
+			pending: 0,
+			processing: 0,
+			completed: 0,
+			failed: 0,
+			cancelled: 0,
+			total: 0,
+		}),
+		cancelJob: async () => null,
+		retryJob: async () => null,
+		rescheduleJob: async () => null,
+		deleteJob: async () => false,
+		cancelJobs: async () => ({ count: 0, errors: [] }),
+		retryJobs: async () => ({ count: 0, errors: [] }),
+		deleteJobs: async () => ({ count: 0, errors: [] }),
+		...overrides,
+	};
+}
+
+async function handleCapabilities(surface: ReturnType<typeof createManagementSurface>) {
+	const result = await surface.openApiHandler.handle(
+		new Request('https://management.example/api/v1/capabilities', { method: 'GET' }),
+	);
+
+	if (!result.matched) {
+		throw new Error('Expected oRPC OpenAPI handler to match capabilities route');
+	}
+
+	return result.response;
+}
+
+describe('oRPC Management capabilities route', () => {
+	test('reports every Management action available when the scheduler supports them', async () => {
+		const surface = createManagementSurface({
+			monque: createManagementMonque(),
+		});
+
+		const response = await handleCapabilities(surface);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			readOnly: false,
+			actions: {
+				read: true,
+				cancel: true,
+				retry: true,
+				reschedule: true,
+				delete: true,
+			},
+		});
+	});
+});

--- a/packages/management/tests/unit/orpc-openapi.test.ts
+++ b/packages/management/tests/unit/orpc-openapi.test.ts
@@ -22,4 +22,23 @@ describe('oRPC Management OpenAPI contract', () => {
 			additionalProperties: false,
 		});
 	});
+
+	test('derives the capabilities path and response schema from the oRPC contract', async () => {
+		const document = await generateManagementOpenApiDocument();
+
+		expect(document.paths?.['/api/v1/capabilities']?.get?.operationId).toBe('getCapabilities');
+		expect(document.paths?.['/api/v1/capabilities']?.get?.responses?.['200']).toMatchObject({
+			description: 'Successful response',
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/Capabilities' },
+				},
+			},
+		});
+		expect(document.components?.schemas?.['Capabilities']).toMatchObject({
+			type: 'object',
+			required: ['readOnly', 'actions'],
+			additionalProperties: false,
+		});
+	});
 });

--- a/packages/management/tests/unit/package-contract.test.ts
+++ b/packages/management/tests/unit/package-contract.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 
+import { CapabilitiesDtoSchema } from '@/index';
+
 interface PackageJson {
 	name: string;
 	private?: boolean;
@@ -49,6 +51,21 @@ describe('@monque/management package contract', () => {
 		expect(Object.keys(packageJson.dependencies ?? {}).sort()).toEqual([
 			...EXPECTED_RUNTIME_DEPENDENCIES,
 		]);
+	});
+
+	test('exports the Zod-derived capabilities DTO schema', () => {
+		expect(
+			CapabilitiesDtoSchema.safeParse({
+				readOnly: false,
+				actions: {
+					read: true,
+					cancel: false,
+					retry: false,
+					reschedule: false,
+					delete: false,
+				},
+			}).success,
+		).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Summary

- add the oRPC `/api/v1/capabilities` route
- derive capabilities DTOs from Zod v4 schemas and export them
- pass adapter-provided oRPC context into Management authorization
- cover capabilities behavior and generated OpenAPI

Closes #436

## Verification

- `bun run test:unit` in `packages/management`
- `bun run check`
