### PR TITLE
feat(management): add oRPC read routes

### DIFF
--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -32,6 +32,10 @@ export {
 export {
 	CapabilitiesDtoSchema,
 	CapabilityActionsDtoSchema,
+	QueueStatsDtoSchema,
+	QueueViewSummaryDtoSchema,
+	QueueViewSummaryListDtoSchema,
+	QueueViewWorkerDtoSchema,
 	SchedulerHealthDtoSchema,
 } from './schemas/index.js';
 export type {

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -2,6 +2,8 @@ import { oc } from '@orpc/contract';
 
 import {
 	CapabilitiesDtoSchema,
+	JobStatsQueryDtoSchema,
+	QueueStatsDtoSchema,
 	QueueViewSummaryListDtoSchema,
 	SchedulerHealthDtoSchema,
 } from '../schemas/index.js';
@@ -34,6 +36,16 @@ export const managementContract = {
 			successDescription: 'Successful response',
 		})
 		.output(QueueViewSummaryListDtoSchema),
+	jobStats: oc
+		.route({
+			method: 'GET',
+			path: '/api/v1/jobs/stats',
+			operationId: 'getJobStats',
+			successStatus: 200,
+			successDescription: 'Successful response',
+		})
+		.input(JobStatsQueryDtoSchema)
+		.output(QueueStatsDtoSchema),
 };
 
 export type ManagementContract = typeof managementContract;

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -1,6 +1,10 @@
 import { oc } from '@orpc/contract';
 
-import { CapabilitiesDtoSchema, SchedulerHealthDtoSchema } from '../schemas/index.js';
+import {
+	CapabilitiesDtoSchema,
+	QueueViewSummaryListDtoSchema,
+	SchedulerHealthDtoSchema,
+} from '../schemas/index.js';
 
 export const managementContract = {
 	health: oc
@@ -21,6 +25,15 @@ export const managementContract = {
 			successDescription: 'Successful response',
 		})
 		.output(CapabilitiesDtoSchema),
+	queueViews: oc
+		.route({
+			method: 'GET',
+			path: '/api/v1/queue-views',
+			operationId: 'listQueueViews',
+			successStatus: 200,
+			successDescription: 'Successful response',
+		})
+		.output(QueueViewSummaryListDtoSchema),
 };
 
 export type ManagementContract = typeof managementContract;

--- a/packages/management/src/orpc/openapi.ts
+++ b/packages/management/src/orpc/openapi.ts
@@ -1,7 +1,12 @@
 import { type OpenAPI, OpenAPIGenerator } from '@orpc/openapi';
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 
-import { CapabilitiesDtoSchema, SchedulerHealthDtoSchema } from '../schemas/index.js';
+import {
+	CapabilitiesDtoSchema,
+	QueueStatsDtoSchema,
+	QueueViewSummaryListDtoSchema,
+	SchedulerHealthDtoSchema,
+} from '../schemas/index.js';
 import { managementContract } from './contract.js';
 
 export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Document> {
@@ -17,6 +22,12 @@ export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Docum
 		commonSchemas: {
 			Capabilities: {
 				schema: CapabilitiesDtoSchema,
+			},
+			QueueStats: {
+				schema: QueueStatsDtoSchema,
+			},
+			QueueViewSummaryList: {
+				schema: QueueViewSummaryListDtoSchema,
 			},
 			SchedulerHealth: {
 				schema: SchedulerHealthDtoSchema,

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -1,8 +1,12 @@
-import { implement } from '@orpc/server';
+import { implement, ORPCError } from '@orpc/server';
 
 import { toQueueStatsDto, toQueueViewSummaryListDto, toSchedulerHealthDto } from '../dtos/index.js';
 import { getManagementCapabilities } from '../surface/capabilities.js';
-import type { ManagementOpenApiContext, ManagementOptions } from '../surface/index.js';
+import type {
+	ManagementAction,
+	ManagementOpenApiContext,
+	ManagementOptions,
+} from '../surface/index.js';
 import { managementContract } from './contract.js';
 
 export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
@@ -16,17 +20,44 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 		capabilities: managementImplementer.capabilities.handler(({ context }) =>
 			getManagementCapabilities(options, context.managementContext as TContext),
 		),
-		queueViews: managementImplementer.queueViews.handler(async () =>
-			toQueueViewSummaryListDto(await options.monque.getQueueViewSummaries()),
-		),
-		jobStats: managementImplementer.jobStats.handler(async ({ input }) =>
-			toQueueStatsDto(
+		queueViews: managementImplementer.queueViews.handler(async ({ context }) => {
+			await requireReadAuthorization(options, context.managementContext as TContext);
+
+			return toQueueViewSummaryListDto(await options.monque.getQueueViewSummaries());
+		}),
+		jobStats: managementImplementer.jobStats.handler(async ({ input, context }) => {
+			await requireReadAuthorization(options, context.managementContext as TContext);
+
+			return toQueueStatsDto(
 				await options.monque.getQueueStats(
 					input.name === undefined ? undefined : { name: input.name },
 				),
-			),
-		),
+			);
+		}),
 	});
 }
 
 export type ManagementRouter = ReturnType<typeof createManagementRouter>;
+
+async function requireReadAuthorization<TContext>(
+	options: ManagementOptions<TContext>,
+	context: TContext,
+): Promise<void> {
+	if (await isAllowedByAuthorization(options, 'read', context)) {
+		return;
+	}
+
+	throw new ORPCError('FORBIDDEN', { message: 'Read access denied' });
+}
+
+async function isAllowedByAuthorization<TContext>(
+	options: ManagementOptions<TContext>,
+	action: ManagementAction,
+	context: TContext,
+): Promise<boolean> {
+	if (!options.authorize) {
+		return true;
+	}
+
+	return options.authorize({ action, context });
+}

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -1,6 +1,6 @@
 import { implement } from '@orpc/server';
 
-import { toSchedulerHealthDto } from '../dtos/index.js';
+import { toQueueViewSummaryListDto, toSchedulerHealthDto } from '../dtos/index.js';
 import { getManagementCapabilities } from '../surface/capabilities.js';
 import type { ManagementOpenApiContext, ManagementOptions } from '../surface/index.js';
 import { managementContract } from './contract.js';
@@ -15,6 +15,9 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 		),
 		capabilities: managementImplementer.capabilities.handler(({ context }) =>
 			getManagementCapabilities(options, context.managementContext as TContext),
+		),
+		queueViews: managementImplementer.queueViews.handler(async () =>
+			toQueueViewSummaryListDto(await options.monque.getQueueViewSummaries()),
 		),
 	});
 }

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -1,6 +1,6 @@
 import { implement } from '@orpc/server';
 
-import { toQueueViewSummaryListDto, toSchedulerHealthDto } from '../dtos/index.js';
+import { toQueueStatsDto, toQueueViewSummaryListDto, toSchedulerHealthDto } from '../dtos/index.js';
 import { getManagementCapabilities } from '../surface/capabilities.js';
 import type { ManagementOpenApiContext, ManagementOptions } from '../surface/index.js';
 import { managementContract } from './contract.js';
@@ -18,6 +18,13 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 		),
 		queueViews: managementImplementer.queueViews.handler(async () =>
 			toQueueViewSummaryListDto(await options.monque.getQueueViewSummaries()),
+		),
+		jobStats: managementImplementer.jobStats.handler(async ({ input }) =>
+			toQueueStatsDto(
+				await options.monque.getQueueStats(
+					input.name === undefined ? undefined : { name: input.name },
+				),
+			),
 		),
 	});
 }

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -5,6 +5,16 @@ export {
 	CapabilityActionsDtoSchema,
 } from './capabilities.js';
 export {
+	type QueueStatsDto,
+	QueueStatsDtoSchema,
+	type QueueViewSummaryDto,
+	QueueViewSummaryDtoSchema,
+	type QueueViewSummaryListDto,
+	QueueViewSummaryListDtoSchema,
+	type QueueViewWorkerDto,
+	QueueViewWorkerDtoSchema,
+} from './queue-view.js';
+export {
 	type SchedulerHealthDto,
 	SchedulerHealthDtoSchema,
 } from './scheduler-health.js';

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -5,6 +5,8 @@ export {
 	CapabilityActionsDtoSchema,
 } from './capabilities.js';
 export {
+	type JobStatsQueryDto,
+	JobStatsQueryDtoSchema,
 	type QueueStatsDto,
 	QueueStatsDtoSchema,
 	type QueueViewSummaryDto,

--- a/packages/management/src/schemas/queue-view.ts
+++ b/packages/management/src/schemas/queue-view.ts
@@ -14,6 +14,14 @@ export const QueueStatsDtoSchema = z
 
 export type QueueStatsDto = z.infer<typeof QueueStatsDtoSchema>;
 
+export const JobStatsQueryDtoSchema = z
+	.object({
+		name: z.string().optional(),
+	})
+	.strict();
+
+export type JobStatsQueryDto = z.infer<typeof JobStatsQueryDtoSchema>;
+
 export const QueueViewWorkerDtoSchema = z
 	.object({
 		concurrency: z.number(),

--- a/packages/management/src/schemas/queue-view.ts
+++ b/packages/management/src/schemas/queue-view.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const QueueStatsDtoSchema = z
+	.object({
+		pending: z.number(),
+		processing: z.number(),
+		completed: z.number(),
+		failed: z.number(),
+		cancelled: z.number(),
+		total: z.number(),
+		avgProcessingDurationMs: z.number().optional(),
+	})
+	.strict();
+
+export type QueueStatsDto = z.infer<typeof QueueStatsDtoSchema>;
+
+export const QueueViewWorkerDtoSchema = z
+	.object({
+		concurrency: z.number(),
+		activeCount: z.number(),
+	})
+	.strict();
+
+export type QueueViewWorkerDto = z.infer<typeof QueueViewWorkerDtoSchema>;
+
+export const QueueViewSummaryDtoSchema = z
+	.object({
+		name: z.string(),
+		hasPersistedJobs: z.boolean(),
+		hasRegisteredWorker: z.boolean(),
+		stats: QueueStatsDtoSchema,
+		worker: QueueViewWorkerDtoSchema.nullable(),
+	})
+	.strict();
+
+export type QueueViewSummaryDto = z.infer<typeof QueueViewSummaryDtoSchema>;
+
+export const QueueViewSummaryListDtoSchema = z
+	.object({
+		queueViews: z.array(QueueViewSummaryDtoSchema),
+	})
+	.strict();
+
+export type QueueViewSummaryListDto = z.infer<typeof QueueViewSummaryListDtoSchema>;

--- a/packages/management/src/surface/surface.ts
+++ b/packages/management/src/surface/surface.ts
@@ -51,7 +51,9 @@ export function createManagementSurface<TContext = unknown>(
 	const router = createManagementRouter(options);
 
 	return {
-		openApiHandler: new OpenAPIHandler(router),
+		openApiHandler: new OpenAPIHandler(router, {
+			customErrorResponseBodyEncoder: (error) => ({ error: error.message }),
+		}),
 		routes: getSupportedManagementRoutes(options.monque),
 		async handle(request: ManagementRequest<TContext>): Promise<ManagementResponse> {
 			try {

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -17,6 +17,10 @@ import type { HttpMethodType, HttpStatusType } from '../http/index.js';
 export type {
 	CapabilitiesDto,
 	CapabilityActionsDto,
+	QueueStatsDto,
+	QueueViewSummaryDto,
+	QueueViewSummaryListDto,
+	QueueViewWorkerDto,
 	SchedulerHealthDto,
 } from '../schemas/index.js';
 
@@ -287,50 +291,6 @@ export interface ManagementRoute {
 
 	/** Explicit non-200 error statuses documented for this route. */
 	errorStatuses?: readonly HttpStatusType[];
-}
-
-/**
- * Queue statistics response DTO.
- */
-export type QueueStatsDto = QueueStats;
-
-/**
- * Local worker state included in queue-view summaries.
- */
-export interface QueueViewWorkerDto {
-	/** Maximum concurrent jobs this worker can process. */
-	concurrency: number;
-
-	/** Number of jobs currently active in this worker. */
-	activeCount: number;
-}
-
-/**
- * Queue-view summary response DTO.
- */
-export interface QueueViewSummaryDto {
-	/** Job name represented by this queue view. */
-	name: string;
-
-	/** Whether at least one persisted job exists for this name. */
-	hasPersistedJobs: boolean;
-
-	/** Whether this scheduler instance has a worker registered for this name. */
-	hasRegisteredWorker: boolean;
-
-	/** Aggregated persisted job statistics for this name. */
-	stats: QueueStatsDto;
-
-	/** Local worker observability, or null when no worker is registered. */
-	worker: QueueViewWorkerDto | null;
-}
-
-/**
- * Queue-view list response DTO.
- */
-export interface QueueViewSummaryListDto {
-	/** Queue views visible to the current scheduler instance. */
-	queueViews: QueueViewSummaryDto[];
 }
 
 /**

--- a/packages/management/tests/unit/orpc-openapi.test.ts
+++ b/packages/management/tests/unit/orpc-openapi.test.ts
@@ -41,4 +41,44 @@ describe('oRPC Management OpenAPI contract', () => {
 			additionalProperties: false,
 		});
 	});
+
+	test('derives Queue View and Job stats paths from the oRPC contract', async () => {
+		const document = await generateManagementOpenApiDocument();
+
+		expect(document.paths?.['/api/v1/queue-views']?.get?.operationId).toBe('listQueueViews');
+		expect(document.paths?.['/api/v1/queue-views']?.get?.responses?.['200']).toMatchObject({
+			description: 'Successful response',
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/QueueViewSummaryList' },
+				},
+			},
+		});
+		expect(document.paths?.['/api/v1/jobs/stats']?.get?.operationId).toBe('getJobStats');
+		expect(document.paths?.['/api/v1/jobs/stats']?.get?.parameters).toEqual([
+			expect.objectContaining({
+				name: 'name',
+				in: 'query',
+				schema: { type: 'string' },
+			}),
+		]);
+		expect(document.paths?.['/api/v1/jobs/stats']?.get?.responses?.['200']).toMatchObject({
+			description: 'Successful response',
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/QueueStats' },
+				},
+			},
+		});
+		expect(document.components?.schemas?.['QueueViewSummaryList']).toMatchObject({
+			type: 'object',
+			required: ['queueViews'],
+			additionalProperties: false,
+		});
+		expect(document.components?.schemas?.['QueueStats']).toMatchObject({
+			type: 'object',
+			required: ['pending', 'processing', 'completed', 'failed', 'cancelled', 'total'],
+			additionalProperties: false,
+		});
+	});
 });

--- a/packages/management/tests/unit/orpc-read-routes.test.ts
+++ b/packages/management/tests/unit/orpc-read-routes.test.ts
@@ -1,0 +1,129 @@
+import type { QueueViewSummary } from '@monque/core';
+import { describe, expect, test } from 'vitest';
+
+import { createManagementSurface } from '@/index';
+import type { ManagementMonque, ManagementOpenApiContext, ManagementSurface } from '@/surface';
+
+function createManagementMonque(overrides: Partial<ManagementMonque> = {}): ManagementMonque {
+	return {
+		isHealthy: () => true,
+		getQueueViewSummaries: async () => [],
+		getJobsWithCursor: async () => ({
+			jobs: [],
+			cursor: null,
+			hasNextPage: false,
+			hasPreviousPage: false,
+		}),
+		getJob: async () => null,
+		getQueueStats: async () => ({
+			pending: 0,
+			processing: 0,
+			completed: 0,
+			failed: 0,
+			cancelled: 0,
+			total: 0,
+		}),
+		...overrides,
+	};
+}
+
+async function handleGet(
+	surface: ManagementSurface,
+	path: string,
+	context?: ManagementOpenApiContext,
+): Promise<Response> {
+	const result = await surface.openApiHandler.handle(
+		new Request(`https://management.example${path}`, { method: 'GET' }),
+		context === undefined ? {} : { context },
+	);
+
+	if (!result.matched) {
+		throw new Error(`Expected oRPC OpenAPI handler to match ${path}`);
+	}
+
+	return result.response;
+}
+
+describe('oRPC Management read routes', () => {
+	test('lists Queue Views through the public scheduler summary API', async () => {
+		const queueViews = [
+			{
+				name: 'send-email',
+				hasPersistedJobs: true,
+				hasRegisteredWorker: true,
+				stats: {
+					pending: 1,
+					processing: 2,
+					completed: 3,
+					failed: 4,
+					cancelled: 5,
+					total: 15,
+					avgProcessingDurationMs: 123,
+				},
+				worker: {
+					concurrency: 10,
+					activeCount: 2,
+				},
+			},
+			{
+				name: 'historical-report',
+				hasPersistedJobs: true,
+				hasRegisteredWorker: false,
+				stats: {
+					pending: 0,
+					processing: 0,
+					completed: 7,
+					failed: 1,
+					cancelled: 0,
+					total: 8,
+				},
+				worker: null,
+			},
+		] satisfies QueueViewSummary[];
+		const surface = createManagementSurface({
+			monque: createManagementMonque({
+				getQueueViewSummaries: async () => queueViews,
+			}),
+		});
+
+		const response = await handleGet(surface, '/api/v1/queue-views');
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			queueViews: [
+				{
+					name: 'send-email',
+					hasPersistedJobs: true,
+					hasRegisteredWorker: true,
+					stats: {
+						pending: 1,
+						processing: 2,
+						completed: 3,
+						failed: 4,
+						cancelled: 5,
+						total: 15,
+						avgProcessingDurationMs: 123,
+					},
+					worker: {
+						concurrency: 10,
+						activeCount: 2,
+					},
+				},
+				{
+					name: 'historical-report',
+					hasPersistedJobs: true,
+					hasRegisteredWorker: false,
+					stats: {
+						pending: 0,
+						processing: 0,
+						completed: 7,
+						failed: 1,
+						cancelled: 0,
+						total: 8,
+					},
+					worker: null,
+				},
+			],
+		});
+	});
+});

--- a/packages/management/tests/unit/orpc-read-routes.test.ts
+++ b/packages/management/tests/unit/orpc-read-routes.test.ts
@@ -212,4 +212,37 @@ describe('oRPC Management read routes', () => {
 		expect(await response.json()).toEqual({ error: 'Input validation failed' });
 		expect(calls).toEqual([]);
 	});
+
+	test('rejects Job stats reads when authorization denies read access', async () => {
+		const calls: unknown[] = [];
+		const statsCalls: string[] = [];
+		const surface = createManagementSurface<{ role: string }>({
+			monque: createManagementMonque({
+				getQueueStats: async () => {
+					statsCalls.push('called');
+					return {
+						pending: 0,
+						processing: 0,
+						completed: 0,
+						failed: 0,
+						cancelled: 0,
+						total: 0,
+					};
+				},
+			}),
+			authorize: ({ action, context }) => {
+				calls.push({ action, context });
+				return false;
+			},
+		});
+
+		const response = await handleGet(surface, '/api/v1/jobs/stats', {
+			managementContext: { role: 'viewer' },
+		});
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toEqual({ error: 'Read access denied' });
+		expect(calls).toEqual([{ action: 'read', context: { role: 'viewer' } }]);
+		expect(statsCalls).toEqual([]);
+	});
 });

--- a/packages/management/tests/unit/orpc-read-routes.test.ts
+++ b/packages/management/tests/unit/orpc-read-routes.test.ts
@@ -187,4 +187,29 @@ describe('oRPC Management read routes', () => {
 		expect(calls).toEqual([{ action: 'read', context: { role: 'viewer' } }]);
 		expect(queueViewCalls).toEqual([]);
 	});
+
+	test('rejects invalid Job stats query shapes before calling core', async () => {
+		const calls: string[] = [];
+		const surface = createManagementSurface({
+			monque: createManagementMonque({
+				getQueueStats: async () => {
+					calls.push('called');
+					return {
+						pending: 0,
+						processing: 0,
+						completed: 0,
+						failed: 0,
+						cancelled: 0,
+						total: 0,
+					};
+				},
+			}),
+		});
+
+		const response = await handleGet(surface, '/api/v1/jobs/stats?name=one&name=two');
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: 'Input validation failed' });
+		expect(calls).toEqual([]);
+	});
 });

--- a/packages/management/tests/unit/orpc-read-routes.test.ts
+++ b/packages/management/tests/unit/orpc-read-routes.test.ts
@@ -1,4 +1,4 @@
-import type { QueueViewSummary } from '@monque/core';
+import type { QueueStats, QueueViewSummary } from '@monque/core';
 import { describe, expect, test } from 'vitest';
 
 import { createManagementSurface } from '@/index';
@@ -124,6 +124,41 @@ describe('oRPC Management read routes', () => {
 					worker: null,
 				},
 			],
+		});
+	});
+
+	test('returns Job statistics through the public scheduler stats API', async () => {
+		const calls: Array<{ name?: string } | undefined> = [];
+		const stats = {
+			pending: 4,
+			processing: 3,
+			completed: 20,
+			failed: 2,
+			cancelled: 1,
+			total: 30,
+			avgProcessingDurationMs: 456,
+		} satisfies QueueStats;
+		const surface = createManagementSurface({
+			monque: createManagementMonque({
+				getQueueStats: async (filter) => {
+					calls.push(filter);
+					return stats;
+				},
+			}),
+		});
+
+		const response = await handleGet(surface, '/api/v1/jobs/stats?name=send-email');
+
+		expect(response.status).toBe(200);
+		expect(calls).toEqual([{ name: 'send-email' }]);
+		expect(await response.json()).toEqual({
+			pending: 4,
+			processing: 3,
+			completed: 20,
+			failed: 2,
+			cancelled: 1,
+			total: 30,
+			avgProcessingDurationMs: 456,
 		});
 	});
 });

--- a/packages/management/tests/unit/orpc-read-routes.test.ts
+++ b/packages/management/tests/unit/orpc-read-routes.test.ts
@@ -161,4 +161,30 @@ describe('oRPC Management read routes', () => {
 			avgProcessingDurationMs: 456,
 		});
 	});
+
+	test('rejects Queue View reads when authorization denies read access', async () => {
+		const calls: unknown[] = [];
+		const queueViewCalls: string[] = [];
+		const surface = createManagementSurface<{ role: string }>({
+			monque: createManagementMonque({
+				getQueueViewSummaries: async () => {
+					queueViewCalls.push('called');
+					return [];
+				},
+			}),
+			authorize: ({ action, context }) => {
+				calls.push({ action, context });
+				return false;
+			},
+		});
+
+		const response = await handleGet(surface, '/api/v1/queue-views', {
+			managementContext: { role: 'viewer' },
+		});
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toEqual({ error: 'Read access denied' });
+		expect(calls).toEqual([{ action: 'read', context: { role: 'viewer' } }]);
+		expect(queueViewCalls).toEqual([]);
+	});
 });

--- a/packages/management/tests/unit/package-contract.test.ts
+++ b/packages/management/tests/unit/package-contract.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 
-import { CapabilitiesDtoSchema } from '@/index';
+import { CapabilitiesDtoSchema, QueueStatsDtoSchema, QueueViewSummaryListDtoSchema } from '@/index';
 
 interface PackageJson {
 	name: string;
@@ -64,6 +64,39 @@ describe('@monque/management package contract', () => {
 					reschedule: false,
 					delete: false,
 				},
+			}).success,
+		).toBe(true);
+	});
+
+	test('exports the Zod-derived read DTO schemas', () => {
+		expect(
+			QueueStatsDtoSchema.safeParse({
+				pending: 1,
+				processing: 2,
+				completed: 3,
+				failed: 4,
+				cancelled: 5,
+				total: 15,
+			}).success,
+		).toBe(true);
+		expect(
+			QueueViewSummaryListDtoSchema.safeParse({
+				queueViews: [
+					{
+						name: 'send-email',
+						hasPersistedJobs: true,
+						hasRegisteredWorker: false,
+						stats: {
+							pending: 1,
+							processing: 0,
+							completed: 0,
+							failed: 0,
+							cancelled: 0,
+							total: 1,
+						},
+						worker: null,
+					},
+				],
 			}).success,
 		).toBe(true);
 	});


### PR DESCRIPTION
## Summary

- Add oRPC Queue View and Job stats read routes.
- Add Zod-derived read DTO schemas/types and root exports.
- Cover read authorization, invalid stats query handling, and generated OpenAPI.

Closes #437

## Verification

- `bun run test:unit` in `packages/management`
- `bun run check`
- `bun run test:unit`
