### PR TITLE
feat(management): add oRPC single-job action routes

### DIFF
--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -34,6 +34,7 @@ export {
 	BulkActionResultDtoSchema,
 	CapabilitiesDtoSchema,
 	CapabilityActionsDtoSchema,
+	DeleteJobDtoSchema,
 	JobCursorPageDtoSchema,
 	JobDetailInputDtoSchema,
 	JobDetailParamsDtoSchema,

--- a/packages/management/src/index.ts
+++ b/packages/management/src/index.ts
@@ -47,6 +47,8 @@ export {
 	QueueViewSummaryDtoSchema,
 	QueueViewSummaryListDtoSchema,
 	QueueViewWorkerDtoSchema,
+	RescheduleJobInputDtoSchema,
+	RescheduleJobRequestDtoSchema,
 	SchedulerHealthDtoSchema,
 } from './schemas/index.js';
 export type {
@@ -81,6 +83,8 @@ export type {
 	QueueViewSummaryDto,
 	QueueViewSummaryListDto,
 	QueueViewWorkerDto,
+	RescheduleJobInputDto,
+	RescheduleJobRequestDto,
 	SchedulerHealthDto,
 } from './surface/index.js';
 export { createManagementSurface } from './surface/index.js';

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -128,6 +128,18 @@ export const managementContract = {
 		.input(JobDetailInputDtoSchema)
 		.errors(SingleJobActionErrors)
 		.output(JobDtoSchema),
+	retryJob: oc
+		.route({
+			method: 'POST',
+			path: '/api/v1/jobs/{id}/actions/retry',
+			operationId: 'retryJob',
+			successStatus: 200,
+			successDescription: 'Successful response',
+			inputStructure: 'detailed',
+		})
+		.input(JobDetailInputDtoSchema)
+		.errors(SingleJobActionErrors)
+		.output(JobDtoSchema),
 	cancelJobs: oc
 		.route({
 			method: 'POST',

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -34,6 +34,29 @@ const BulkActionErrors = {
 	},
 } as const;
 
+const SingleJobActionErrors = {
+	BAD_REQUEST: {
+		status: 400,
+		data: ManagementErrorDtoSchema,
+	},
+	FORBIDDEN: {
+		status: 403,
+		data: ManagementErrorDtoSchema,
+	},
+	NOT_FOUND: {
+		status: 404,
+		data: ManagementErrorDtoSchema,
+	},
+	CONFLICT: {
+		status: 409,
+		data: ManagementErrorDtoSchema,
+	},
+	INTERNAL_SERVER_ERROR: {
+		status: 500,
+		data: ManagementErrorDtoSchema,
+	},
+} as const;
+
 export const managementContract = {
 	health: oc
 		.route({
@@ -92,6 +115,18 @@ export const managementContract = {
 			inputStructure: 'detailed',
 		})
 		.input(JobDetailInputDtoSchema)
+		.output(JobDtoSchema),
+	cancelJob: oc
+		.route({
+			method: 'POST',
+			path: '/api/v1/jobs/{id}/actions/cancel',
+			operationId: 'cancelJob',
+			successStatus: 200,
+			successDescription: 'Successful response',
+			inputStructure: 'detailed',
+		})
+		.input(JobDetailInputDtoSchema)
+		.errors(SingleJobActionErrors)
 		.output(JobDtoSchema),
 	cancelJobs: oc
 		.route({

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -3,6 +3,7 @@ import { oc } from '@orpc/contract';
 import {
 	BulkActionResultDtoSchema,
 	CapabilitiesDtoSchema,
+	DeleteJobDtoSchema,
 	JobCursorPageDtoSchema,
 	JobDetailInputDtoSchema,
 	JobDtoSchema,
@@ -140,6 +141,18 @@ export const managementContract = {
 		.input(JobDetailInputDtoSchema)
 		.errors(SingleJobActionErrors)
 		.output(JobDtoSchema),
+	deleteJob: oc
+		.route({
+			method: 'DELETE',
+			path: '/api/v1/jobs/{id}',
+			operationId: 'deleteJob',
+			successStatus: 200,
+			successDescription: 'Successful response',
+			inputStructure: 'detailed',
+		})
+		.input(JobDetailInputDtoSchema)
+		.errors(SingleJobActionErrors)
+		.output(DeleteJobDtoSchema),
 	cancelJobs: oc
 		.route({
 			method: 'POST',

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -17,7 +17,7 @@ import {
 	SchedulerHealthDtoSchema,
 } from '../schemas/index.js';
 
-const BulkActionErrors = {
+const ManagementMutationErrors = {
 	BAD_REQUEST: {
 		status: 400,
 		data: ManagementErrorDtoSchema,
@@ -37,24 +37,9 @@ const BulkActionErrors = {
 } as const;
 
 const SingleJobActionErrors = {
-	BAD_REQUEST: {
-		status: 400,
-		data: ManagementErrorDtoSchema,
-	},
-	FORBIDDEN: {
-		status: 403,
-		data: ManagementErrorDtoSchema,
-	},
+	...ManagementMutationErrors,
 	NOT_FOUND: {
 		status: 404,
-		data: ManagementErrorDtoSchema,
-	},
-	CONFLICT: {
-		status: 409,
-		data: ManagementErrorDtoSchema,
-	},
-	INTERNAL_SERVER_ERROR: {
-		status: 500,
 		data: ManagementErrorDtoSchema,
 	},
 } as const;
@@ -175,7 +160,7 @@ export const managementContract = {
 			successDescription: 'Successful response',
 		})
 		.input(JobSelectorDtoSchema)
-		.errors(BulkActionErrors)
+		.errors(ManagementMutationErrors)
 		.output(BulkActionResultDtoSchema),
 	retryJobs: oc
 		.route({
@@ -186,7 +171,7 @@ export const managementContract = {
 			successDescription: 'Successful response',
 		})
 		.input(JobSelectorDtoSchema)
-		.errors(BulkActionErrors)
+		.errors(ManagementMutationErrors)
 		.output(BulkActionResultDtoSchema),
 	deleteJobs: oc
 		.route({
@@ -197,7 +182,7 @@ export const managementContract = {
 			successDescription: 'Successful response',
 		})
 		.input(JobSelectorDtoSchema)
-		.errors(BulkActionErrors)
+		.errors(ManagementMutationErrors)
 		.output(BulkActionResultDtoSchema),
 };
 

--- a/packages/management/src/orpc/contract.ts
+++ b/packages/management/src/orpc/contract.ts
@@ -13,6 +13,7 @@ import {
 	ManagementErrorDtoSchema,
 	QueueStatsDtoSchema,
 	QueueViewSummaryListDtoSchema,
+	RescheduleJobInputDtoSchema,
 	SchedulerHealthDtoSchema,
 } from '../schemas/index.js';
 
@@ -139,6 +140,18 @@ export const managementContract = {
 			inputStructure: 'detailed',
 		})
 		.input(JobDetailInputDtoSchema)
+		.errors(SingleJobActionErrors)
+		.output(JobDtoSchema),
+	rescheduleJob: oc
+		.route({
+			method: 'POST',
+			path: '/api/v1/jobs/{id}/actions/reschedule',
+			operationId: 'rescheduleJob',
+			successStatus: 200,
+			successDescription: 'Successful response',
+			inputStructure: 'detailed',
+		})
+		.input(RescheduleJobInputDtoSchema)
 		.errors(SingleJobActionErrors)
 		.output(JobDtoSchema),
 	deleteJob: oc

--- a/packages/management/src/orpc/openapi.ts
+++ b/packages/management/src/orpc/openapi.ts
@@ -4,12 +4,14 @@ import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 import {
 	BulkActionResultDtoSchema,
 	CapabilitiesDtoSchema,
+	DeleteJobDtoSchema,
 	JobCursorPageDtoSchema,
 	JobDtoSchema,
 	JobSelectorDtoSchema,
 	ManagementErrorDtoSchema,
 	QueueStatsDtoSchema,
 	QueueViewSummaryListDtoSchema,
+	RescheduleJobRequestDtoSchema,
 	SchedulerHealthDtoSchema,
 } from '../schemas/index.js';
 import { managementContract } from './contract.js';
@@ -41,6 +43,9 @@ export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Docum
 			BulkActionResult: {
 				schema: BulkActionResultDtoSchema,
 			},
+			DeleteJob: {
+				schema: DeleteJobDtoSchema,
+			},
 			ManagementError: {
 				schema: ManagementErrorDtoSchema,
 			},
@@ -49,6 +54,9 @@ export async function generateManagementOpenApiDocument(): Promise<OpenAPI.Docum
 			},
 			QueueViewSummaryList: {
 				schema: QueueViewSummaryListDtoSchema,
+			},
+			RescheduleJobRequest: {
+				schema: RescheduleJobRequestDtoSchema,
 			},
 			SchedulerHealth: {
 				schema: SchedulerHealthDtoSchema,

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -29,9 +29,8 @@ import { managementContract } from './contract.js';
 
 type BulkManagementAction = Exclude<ManagementAction, 'read' | 'reschedule'>;
 type BulkJobMutator = (selector: JobSelector) => Promise<BulkOperationResult>;
-type SingleJobMutationAction = Exclude<ManagementAction, 'read' | 'delete' | 'reschedule'>;
+type SingleJobMutationAction = Exclude<ManagementAction, 'read' | 'delete'>;
 type SingleJobMutator = (id: string) => Promise<PersistedJob | null>;
-type RescheduleJobMutator = (id: string, runAt: Date) => Promise<PersistedJob | null>;
 type DeleteJobMutator = (id: string) => Promise<boolean>;
 
 export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
@@ -117,15 +116,17 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options.monque.retryJob?.bind(options.monque),
 			),
 		),
-		rescheduleJob: managementImplementer.rescheduleJob.handler(async ({ input, context }) =>
-			handleRescheduleJob(
+		rescheduleJob: managementImplementer.rescheduleJob.handler(async ({ input, context }) => {
+			const rescheduleJob = options.monque.rescheduleJob?.bind(options.monque);
+
+			return handleSingleJobMutation(
 				options,
+				'reschedule',
 				input.params.id,
-				input.body.nextRunAt,
 				context.managementContext as TContext,
-				options.monque.rescheduleJob?.bind(options.monque),
-			),
-		),
+				rescheduleJob ? (id) => rescheduleJob(id, new Date(input.body.nextRunAt)) : undefined,
+			);
+		}),
 		deleteJob: managementImplementer.deleteJob.handler(async ({ input, context }) =>
 			handleDeleteJob(
 				options,
@@ -171,80 +172,11 @@ async function handleSingleJobMutation<TContext>(
 	context: TContext,
 	mutate: SingleJobMutator | undefined,
 ) {
-	if (options.readOnly) {
-		throw new ORPCError('FORBIDDEN', { message: 'Management surface is read-only' });
-	}
-
-	if (!mutate) {
-		throw new ORPCError('FORBIDDEN', { message: 'Unsupported action' });
-	}
-
-	const id = parseObjectId(idInput);
-
-	if ('error' in id) {
-		throw new ORPCError('BAD_REQUEST', { message: id.error });
-	}
-
-	const target = await options.monque.getJob(id.value);
-
-	if (!target) {
-		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
-	}
-
-	if (!(await isAllowedByAuthorization(options, action, context, target))) {
-		throw new ORPCError('FORBIDDEN', { message: 'Action denied' });
-	}
+	const supportedMutate = requireSingleJobMutator(options, mutate);
+	const id = await resolveSingleJobTarget(options, action, idInput, context);
 
 	try {
-		const job = await mutate(id.value.toHexString());
-
-		if (!job) {
-			throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
-		}
-
-		return toJobDto(options, job, context);
-	} catch (error) {
-		if (error instanceof JobStateError) {
-			throw new ORPCError('CONFLICT', { message: error.message });
-		}
-
-		throw error;
-	}
-}
-
-async function handleRescheduleJob<TContext>(
-	options: ManagementOptions<TContext>,
-	idInput: string,
-	nextRunAtInput: string,
-	context: TContext,
-	mutate: RescheduleJobMutator | undefined,
-) {
-	if (options.readOnly) {
-		throw new ORPCError('FORBIDDEN', { message: 'Management surface is read-only' });
-	}
-
-	if (!mutate) {
-		throw new ORPCError('FORBIDDEN', { message: 'Unsupported action' });
-	}
-
-	const id = parseObjectId(idInput);
-
-	if ('error' in id) {
-		throw new ORPCError('BAD_REQUEST', { message: id.error });
-	}
-
-	const target = await options.monque.getJob(id.value);
-
-	if (!target) {
-		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
-	}
-
-	if (!(await isAllowedByAuthorization(options, 'reschedule', context, target))) {
-		throw new ORPCError('FORBIDDEN', { message: 'Action denied' });
-	}
-
-	try {
-		const job = await mutate(id.value.toHexString(), new Date(nextRunAtInput));
+		const job = await supportedMutate(id);
 
 		if (!job) {
 			throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
@@ -266,6 +198,21 @@ async function handleDeleteJob<TContext>(
 	context: TContext,
 	mutate: DeleteJobMutator | undefined,
 ) {
+	const supportedMutate = requireSingleJobMutator(options, mutate);
+	const id = await resolveSingleJobTarget(options, 'delete', idInput, context);
+	const deleted = await supportedMutate(id);
+
+	if (!deleted) {
+		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+	}
+
+	return toDeleteJobDto();
+}
+
+function requireSingleJobMutator<TContext, TMutator>(
+	options: ManagementOptions<TContext>,
+	mutate: TMutator | undefined,
+): TMutator {
 	if (options.readOnly) {
 		throw new ORPCError('FORBIDDEN', { message: 'Management surface is read-only' });
 	}
@@ -274,6 +221,15 @@ async function handleDeleteJob<TContext>(
 		throw new ORPCError('FORBIDDEN', { message: 'Unsupported action' });
 	}
 
+	return mutate;
+}
+
+async function resolveSingleJobTarget<TContext>(
+	options: ManagementOptions<TContext>,
+	action: Exclude<ManagementAction, 'read'>,
+	idInput: string,
+	context: TContext,
+): Promise<string> {
 	const id = parseObjectId(idInput);
 
 	if ('error' in id) {
@@ -286,17 +242,11 @@ async function handleDeleteJob<TContext>(
 		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
 	}
 
-	if (!(await isAllowedByAuthorization(options, 'delete', context, target))) {
+	if (!(await isAllowedByAuthorization(options, action, context, target))) {
 		throw new ORPCError('FORBIDDEN', { message: 'Action denied' });
 	}
 
-	const deleted = await mutate(id.value.toHexString());
-
-	if (!deleted) {
-		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
-	}
-
-	return toDeleteJobDto();
+	return id.value.toHexString();
 }
 
 function toManagementQuery(input: JobListQueryDto): Record<string, ManagementQueryValue> {

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -31,6 +31,7 @@ type BulkManagementAction = Exclude<ManagementAction, 'read' | 'reschedule'>;
 type BulkJobMutator = (selector: JobSelector) => Promise<BulkOperationResult>;
 type SingleJobMutationAction = Exclude<ManagementAction, 'read' | 'delete' | 'reschedule'>;
 type SingleJobMutator = (id: string) => Promise<PersistedJob | null>;
+type RescheduleJobMutator = (id: string, runAt: Date) => Promise<PersistedJob | null>;
 type DeleteJobMutator = (id: string) => Promise<boolean>;
 
 export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
@@ -116,6 +117,15 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options.monque.retryJob?.bind(options.monque),
 			),
 		),
+		rescheduleJob: managementImplementer.rescheduleJob.handler(async ({ input, context }) =>
+			handleRescheduleJob(
+				options,
+				input.params.id,
+				input.body.nextRunAt,
+				context.managementContext as TContext,
+				options.monque.rescheduleJob?.bind(options.monque),
+			),
+		),
 		deleteJob: managementImplementer.deleteJob.handler(async ({ input, context }) =>
 			handleDeleteJob(
 				options,
@@ -187,6 +197,54 @@ async function handleSingleJobMutation<TContext>(
 
 	try {
 		const job = await mutate(id.value.toHexString());
+
+		if (!job) {
+			throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+		}
+
+		return toJobDto(options, job, context);
+	} catch (error) {
+		if (error instanceof JobStateError) {
+			throw new ORPCError('CONFLICT', { message: error.message });
+		}
+
+		throw error;
+	}
+}
+
+async function handleRescheduleJob<TContext>(
+	options: ManagementOptions<TContext>,
+	idInput: string,
+	nextRunAtInput: string,
+	context: TContext,
+	mutate: RescheduleJobMutator | undefined,
+) {
+	if (options.readOnly) {
+		throw new ORPCError('FORBIDDEN', { message: 'Management surface is read-only' });
+	}
+
+	if (!mutate) {
+		throw new ORPCError('FORBIDDEN', { message: 'Unsupported action' });
+	}
+
+	const id = parseObjectId(idInput);
+
+	if ('error' in id) {
+		throw new ORPCError('BAD_REQUEST', { message: id.error });
+	}
+
+	const target = await options.monque.getJob(id.value);
+
+	if (!target) {
+		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+	}
+
+	if (!(await isAllowedByAuthorization(options, 'reschedule', context, target))) {
+		throw new ORPCError('FORBIDDEN', { message: 'Action denied' });
+	}
+
+	try {
+		const job = await mutate(id.value.toHexString(), new Date(nextRunAtInput));
 
 		if (!job) {
 			throw new ORPCError('NOT_FOUND', { message: 'Job not found' });

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -105,6 +105,15 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options.monque.cancelJob?.bind(options.monque),
 			),
 		),
+		retryJob: managementImplementer.retryJob.handler(async ({ input, context }) =>
+			handleSingleJobMutation(
+				options,
+				'retry',
+				input.params.id,
+				context.managementContext as TContext,
+				options.monque.retryJob?.bind(options.monque),
+			),
+		),
 		cancelJobs: managementImplementer.cancelJobs.handler(async ({ input, context }) =>
 			handleBulkJobMutation(
 				options,

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -9,6 +9,7 @@ import { implement, ORPCError } from '@orpc/server';
 
 import {
 	toBulkActionResultDto,
+	toDeleteJobDto,
 	toJobCursorPageDto,
 	toJobDto,
 	toQueueStatsDto,
@@ -30,6 +31,7 @@ type BulkManagementAction = Exclude<ManagementAction, 'read' | 'reschedule'>;
 type BulkJobMutator = (selector: JobSelector) => Promise<BulkOperationResult>;
 type SingleJobMutationAction = Exclude<ManagementAction, 'read' | 'delete' | 'reschedule'>;
 type SingleJobMutator = (id: string) => Promise<PersistedJob | null>;
+type DeleteJobMutator = (id: string) => Promise<boolean>;
 
 export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
 	const managementImplementer =
@@ -114,6 +116,14 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options.monque.retryJob?.bind(options.monque),
 			),
 		),
+		deleteJob: managementImplementer.deleteJob.handler(async ({ input, context }) =>
+			handleDeleteJob(
+				options,
+				input.params.id,
+				context.managementContext as TContext,
+				options.monque.deleteJob?.bind(options.monque),
+			),
+		),
 		cancelJobs: managementImplementer.cancelJobs.handler(async ({ input, context }) =>
 			handleBulkJobMutation(
 				options,
@@ -190,6 +200,45 @@ async function handleSingleJobMutation<TContext>(
 
 		throw error;
 	}
+}
+
+async function handleDeleteJob<TContext>(
+	options: ManagementOptions<TContext>,
+	idInput: string,
+	context: TContext,
+	mutate: DeleteJobMutator | undefined,
+) {
+	if (options.readOnly) {
+		throw new ORPCError('FORBIDDEN', { message: 'Management surface is read-only' });
+	}
+
+	if (!mutate) {
+		throw new ORPCError('FORBIDDEN', { message: 'Unsupported action' });
+	}
+
+	const id = parseObjectId(idInput);
+
+	if ('error' in id) {
+		throw new ORPCError('BAD_REQUEST', { message: id.error });
+	}
+
+	const target = await options.monque.getJob(id.value);
+
+	if (!target) {
+		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+	}
+
+	if (!(await isAllowedByAuthorization(options, 'delete', context, target))) {
+		throw new ORPCError('FORBIDDEN', { message: 'Action denied' });
+	}
+
+	const deleted = await mutate(id.value.toHexString());
+
+	if (!deleted) {
+		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+	}
+
+	return toDeleteJobDto();
 }
 
 function toManagementQuery(input: JobListQueryDto): Record<string, ManagementQueryValue> {

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -42,15 +42,19 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 			toSchedulerHealthDto(options.monque.isHealthy()),
 		),
 		capabilities: managementImplementer.capabilities.handler(({ context }) =>
-			getManagementCapabilities(options, context.managementContext as TContext),
+			getManagementCapabilities(options, getOpenApiManagementContext(context)),
 		),
 		queueViews: managementImplementer.queueViews.handler(async ({ context }) => {
-			await requireReadAuthorization(options, context.managementContext as TContext);
+			const managementContext = getOpenApiManagementContext(context);
+
+			await requireReadAuthorization(options, managementContext);
 
 			return toQueueViewSummaryListDto(await options.monque.getQueueViewSummaries());
 		}),
 		jobs: managementImplementer.jobs.handler(async ({ input, context }) => {
-			await requireReadAuthorization(options, context.managementContext as TContext);
+			const managementContext = getOpenApiManagementContext(context);
+
+			await requireReadAuthorization(options, managementContext);
 
 			const cursorOptions = parseJobListQuery(toManagementQuery(input));
 
@@ -62,7 +66,7 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				return await toJobCursorPageDto(
 					options,
 					await options.monque.getJobsWithCursor(cursorOptions),
-					context.managementContext as TContext,
+					managementContext,
 				);
 			} catch (error) {
 				if (error instanceof InvalidCursorError) {
@@ -73,7 +77,9 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 			}
 		}),
 		jobStats: managementImplementer.jobStats.handler(async ({ input, context }) => {
-			await requireReadAuthorization(options, context.managementContext as TContext);
+			const managementContext = getOpenApiManagementContext(context);
+
+			await requireReadAuthorization(options, managementContext);
 
 			return toQueueStatsDto(
 				await options.monque.getQueueStats(
@@ -82,7 +88,9 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 			);
 		}),
 		job: managementImplementer.job.handler(async ({ input, context }) => {
-			await requireReadAuthorization(options, context.managementContext as TContext);
+			const managementContext = getOpenApiManagementContext(context);
+
+			await requireReadAuthorization(options, managementContext);
 
 			const id = parseObjectId(input.params.id);
 
@@ -96,14 +104,14 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
 			}
 
-			return toJobDto(options, job, context.managementContext as TContext);
+			return toJobDto(options, job, managementContext);
 		}),
 		cancelJob: managementImplementer.cancelJob.handler(async ({ input, context }) =>
 			handleSingleJobMutation(
 				options,
 				'cancel',
 				input.params.id,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				options.monque.cancelJob?.bind(options.monque),
 			),
 		),
@@ -112,7 +120,7 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options,
 				'retry',
 				input.params.id,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				options.monque.retryJob?.bind(options.monque),
 			),
 		),
@@ -123,7 +131,7 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options,
 				'reschedule',
 				input.params.id,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				rescheduleJob ? (id) => rescheduleJob(id, new Date(input.body.nextRunAt)) : undefined,
 			);
 		}),
@@ -131,7 +139,7 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 			handleDeleteJob(
 				options,
 				input.params.id,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				options.monque.deleteJob?.bind(options.monque),
 			),
 		),
@@ -140,7 +148,7 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options,
 				'cancel',
 				input,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				options.monque.cancelJobs?.bind(options.monque),
 			),
 		),
@@ -149,7 +157,7 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options,
 				'retry',
 				input,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				options.monque.retryJobs?.bind(options.monque),
 			),
 		),
@@ -158,11 +166,17 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 				options,
 				'delete',
 				input,
-				context.managementContext as TContext,
+				getOpenApiManagementContext(context),
 				options.monque.deleteJobs?.bind(options.monque),
 			),
 		),
 	});
+}
+
+function getOpenApiManagementContext<TContext>(
+	context: ManagementOpenApiContext<TContext>,
+): TContext {
+	return context.managementContext as TContext;
 }
 
 async function handleSingleJobMutation<TContext>(

--- a/packages/management/src/orpc/router.ts
+++ b/packages/management/src/orpc/router.ts
@@ -3,6 +3,7 @@ import {
 	InvalidCursorError,
 	type JobSelector,
 	JobStateError,
+	type PersistedJob,
 } from '@monque/core';
 import { implement, ORPCError } from '@orpc/server';
 
@@ -27,6 +28,8 @@ import { managementContract } from './contract.js';
 
 type BulkManagementAction = Exclude<ManagementAction, 'read' | 'reschedule'>;
 type BulkJobMutator = (selector: JobSelector) => Promise<BulkOperationResult>;
+type SingleJobMutationAction = Exclude<ManagementAction, 'read' | 'delete' | 'reschedule'>;
+type SingleJobMutator = (id: string) => Promise<PersistedJob | null>;
 
 export function createManagementRouter<TContext = unknown>(options: ManagementOptions<TContext>) {
 	const managementImplementer =
@@ -93,6 +96,15 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 
 			return toJobDto(options, job, context.managementContext as TContext);
 		}),
+		cancelJob: managementImplementer.cancelJob.handler(async ({ input, context }) =>
+			handleSingleJobMutation(
+				options,
+				'cancel',
+				input.params.id,
+				context.managementContext as TContext,
+				options.monque.cancelJob?.bind(options.monque),
+			),
+		),
 		cancelJobs: managementImplementer.cancelJobs.handler(async ({ input, context }) =>
 			handleBulkJobMutation(
 				options,
@@ -121,6 +133,54 @@ export function createManagementRouter<TContext = unknown>(options: ManagementOp
 			),
 		),
 	});
+}
+
+async function handleSingleJobMutation<TContext>(
+	options: ManagementOptions<TContext>,
+	action: SingleJobMutationAction,
+	idInput: string,
+	context: TContext,
+	mutate: SingleJobMutator | undefined,
+) {
+	if (options.readOnly) {
+		throw new ORPCError('FORBIDDEN', { message: 'Management surface is read-only' });
+	}
+
+	if (!mutate) {
+		throw new ORPCError('FORBIDDEN', { message: 'Unsupported action' });
+	}
+
+	const id = parseObjectId(idInput);
+
+	if ('error' in id) {
+		throw new ORPCError('BAD_REQUEST', { message: id.error });
+	}
+
+	const target = await options.monque.getJob(id.value);
+
+	if (!target) {
+		throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+	}
+
+	if (!(await isAllowedByAuthorization(options, action, context, target))) {
+		throw new ORPCError('FORBIDDEN', { message: 'Action denied' });
+	}
+
+	try {
+		const job = await mutate(id.value.toHexString());
+
+		if (!job) {
+			throw new ORPCError('NOT_FOUND', { message: 'Job not found' });
+		}
+
+		return toJobDto(options, job, context);
+	} catch (error) {
+		if (error instanceof JobStateError) {
+			throw new ORPCError('CONFLICT', { message: error.message });
+		}
+
+		throw error;
+	}
 }
 
 function toManagementQuery(input: JobListQueryDto): Record<string, ManagementQueryValue> {
@@ -216,7 +276,7 @@ async function isAllowedByAuthorization<TContext>(
 	options: ManagementOptions<TContext>,
 	action: ManagementAction,
 	context: TContext,
-	job?: never,
+	job?: PersistedJob,
 	selector?: JobSelector,
 ): Promise<boolean> {
 	if (!options.authorize) {

--- a/packages/management/src/schemas/actions.ts
+++ b/packages/management/src/schemas/actions.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { JobStatusDtoSchema } from './job.js';
+import { JobDetailParamsDtoSchema, JobStatusDtoSchema } from './job.js';
 
 export const JobSelectorDtoSchema = z
 	.object({
@@ -38,6 +38,25 @@ export const DeleteJobDtoSchema = z
 	.strict();
 
 export type DeleteJobDto = z.infer<typeof DeleteJobDtoSchema>;
+
+export const RescheduleJobRequestDtoSchema = z
+	.object({
+		nextRunAt: z.iso.datetime(),
+	})
+	.strict();
+
+export type RescheduleJobRequestDto = z.infer<typeof RescheduleJobRequestDtoSchema>;
+
+export const RescheduleJobInputDtoSchema = z
+	.object({
+		params: JobDetailParamsDtoSchema,
+		query: z.object({}).strict().optional(),
+		headers: z.looseObject({}).optional(),
+		body: RescheduleJobRequestDtoSchema,
+	})
+	.strict();
+
+export type RescheduleJobInputDto = z.infer<typeof RescheduleJobInputDtoSchema>;
 
 export const ManagementErrorDtoSchema = z
 	.object({

--- a/packages/management/src/schemas/actions.ts
+++ b/packages/management/src/schemas/actions.ts
@@ -31,6 +31,14 @@ export const BulkActionResultDtoSchema = z
 
 export type BulkActionResultDto = z.infer<typeof BulkActionResultDtoSchema>;
 
+export const DeleteJobDtoSchema = z
+	.object({
+		deleted: z.literal(true),
+	})
+	.strict();
+
+export type DeleteJobDto = z.infer<typeof DeleteJobDtoSchema>;
+
 export const ManagementErrorDtoSchema = z
 	.object({
 		error: z.string(),

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -3,6 +3,8 @@ export {
 	BulkActionErrorDtoSchema,
 	type BulkActionResultDto,
 	BulkActionResultDtoSchema,
+	type DeleteJobDto,
+	DeleteJobDtoSchema,
 	type JobSelectorDto,
 	JobSelectorDtoSchema,
 	type ManagementErrorDto,

--- a/packages/management/src/schemas/index.ts
+++ b/packages/management/src/schemas/index.ts
@@ -9,6 +9,10 @@ export {
 	JobSelectorDtoSchema,
 	type ManagementErrorDto,
 	ManagementErrorDtoSchema,
+	type RescheduleJobInputDto,
+	RescheduleJobInputDtoSchema,
+	type RescheduleJobRequestDto,
+	RescheduleJobRequestDtoSchema,
 } from './actions.js';
 export {
 	type CapabilitiesDto,

--- a/packages/management/src/surface/index.ts
+++ b/packages/management/src/surface/index.ts
@@ -32,5 +32,7 @@ export type {
 	QueueViewSummaryDto,
 	QueueViewSummaryListDto,
 	QueueViewWorkerDto,
+	RescheduleJobInputDto,
+	RescheduleJobRequestDto,
 	SchedulerHealthDto,
 } from './types.js';

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -31,6 +31,8 @@ export type {
 	QueueViewSummaryDto,
 	QueueViewSummaryListDto,
 	QueueViewWorkerDto,
+	RescheduleJobInputDto,
+	RescheduleJobRequestDto,
 	SchedulerHealthDto,
 } from '../schemas/index.js';
 

--- a/packages/management/src/surface/types.ts
+++ b/packages/management/src/surface/types.ts
@@ -18,6 +18,7 @@ export type {
 	BulkActionResultDto,
 	CapabilitiesDto,
 	CapabilityActionsDto,
+	DeleteJobDto,
 	JobCursorPageDto,
 	JobDetailInputDto,
 	JobDetailParamsDto,
@@ -300,14 +301,6 @@ export interface ManagementRoute {
 
 	/** Explicit non-200 error statuses documented for this route. */
 	errorStatuses?: readonly HttpStatusType[];
-}
-
-/**
- * Delete-job response DTO.
- */
-export interface DeleteJobDto {
-	/** Literal confirmation that the job was deleted. */
-	deleted: true;
 }
 
 /**

--- a/packages/management/tests/unit/orpc-openapi.test.ts
+++ b/packages/management/tests/unit/orpc-openapi.test.ts
@@ -239,6 +239,14 @@ describe('oRPC Management OpenAPI contract', () => {
 				});
 			}
 		}
+		expect(document.paths?.['/api/v1/jobs/{id}']?.delete?.parameters).toEqual([
+			expect.objectContaining({
+				name: 'id',
+				in: 'path',
+				required: true,
+				schema: { type: 'string' },
+			}),
+		]);
 		expect(
 			document.paths?.['/api/v1/jobs/{id}/actions/reschedule']?.post?.requestBody,
 		).toMatchObject({
@@ -250,7 +258,9 @@ describe('oRPC Management OpenAPI contract', () => {
 			},
 		});
 		expect(document.paths?.['/api/v1/jobs/{id}']?.delete?.operationId).toBe('deleteJob');
-		expect(document.paths?.['/api/v1/jobs/{id}']?.delete?.responses?.['200']).toMatchObject({
+		const deleteResponses = document.paths?.['/api/v1/jobs/{id}']?.delete?.responses;
+
+		expect(deleteResponses?.['200']).toMatchObject({
 			description: 'Successful response',
 			content: {
 				'application/json': {
@@ -258,6 +268,15 @@ describe('oRPC Management OpenAPI contract', () => {
 				},
 			},
 		});
+		for (const status of ['400', '403', '404', '409', '500']) {
+			expect(deleteResponses?.[status]).toMatchObject({
+				content: {
+					'application/json': {
+						schema: { $ref: '#/components/schemas/ManagementError' },
+					},
+				},
+			});
+		}
 		expect(document.components?.schemas?.['RescheduleJobRequest']).toMatchObject({
 			type: 'object',
 			required: ['nextRunAt'],

--- a/packages/management/tests/unit/orpc-openapi.test.ts
+++ b/packages/management/tests/unit/orpc-openapi.test.ts
@@ -200,4 +200,73 @@ describe('oRPC Management OpenAPI contract', () => {
 			additionalProperties: false,
 		});
 	});
+
+	test('derives single Job action paths, schemas, and error statuses from the oRPC contract', async () => {
+		const document = await generateManagementOpenApiDocument();
+		const jobResponseRoutes = [
+			['/api/v1/jobs/{id}/actions/cancel', 'cancelJob'],
+			['/api/v1/jobs/{id}/actions/retry', 'retryJob'],
+			['/api/v1/jobs/{id}/actions/reschedule', 'rescheduleJob'],
+		] as const;
+
+		for (const [path, operationId] of jobResponseRoutes) {
+			const operation = document.paths?.[path]?.post;
+
+			expect(operation?.operationId).toBe(operationId);
+			expect(operation?.parameters).toEqual([
+				expect.objectContaining({
+					name: 'id',
+					in: 'path',
+					required: true,
+					schema: { type: 'string' },
+				}),
+			]);
+			expect(operation?.responses?.['200']).toMatchObject({
+				description: 'Successful response',
+				content: {
+					'application/json': {
+						schema: { $ref: '#/components/schemas/Job' },
+					},
+				},
+			});
+			for (const status of ['400', '403', '404', '409', '500']) {
+				expect(operation?.responses?.[status]).toMatchObject({
+					content: {
+						'application/json': {
+							schema: { $ref: '#/components/schemas/ManagementError' },
+						},
+					},
+				});
+			}
+		}
+		expect(
+			document.paths?.['/api/v1/jobs/{id}/actions/reschedule']?.post?.requestBody,
+		).toMatchObject({
+			required: true,
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/RescheduleJobRequest' },
+				},
+			},
+		});
+		expect(document.paths?.['/api/v1/jobs/{id}']?.delete?.operationId).toBe('deleteJob');
+		expect(document.paths?.['/api/v1/jobs/{id}']?.delete?.responses?.['200']).toMatchObject({
+			description: 'Successful response',
+			content: {
+				'application/json': {
+					schema: { $ref: '#/components/schemas/DeleteJob' },
+				},
+			},
+		});
+		expect(document.components?.schemas?.['RescheduleJobRequest']).toMatchObject({
+			type: 'object',
+			required: ['nextRunAt'],
+			additionalProperties: false,
+		});
+		expect(document.components?.schemas?.['DeleteJob']).toMatchObject({
+			type: 'object',
+			required: ['deleted'],
+			additionalProperties: false,
+		});
+	});
 });

--- a/packages/management/tests/unit/orpc-single-job-actions.test.ts
+++ b/packages/management/tests/unit/orpc-single-job-actions.test.ts
@@ -201,4 +201,44 @@ describe('oRPC Management single Job action routes', () => {
 		expect(await response.json()).toEqual({ deleted: true });
 		expect(coreCalls).toEqual([jobId.toHexString()]);
 	});
+
+	test('reschedules one Job with an ISO date DTO mapped to core Date', async () => {
+		const jobId = new ObjectId();
+		const target = createJob({ _id: jobId });
+		const rescheduled = createJob({
+			_id: jobId,
+			nextRunAt: new Date('2026-02-01T10:30:00.000Z'),
+			updatedAt: new Date('2026-01-01T00:04:00.000Z'),
+		});
+		const coreCalls: Array<{ id: string; runAt: Date }> = [];
+		const surface = createManagementSurface({
+			monque: createManagementMonque({
+				getJob: async (id) => (id.equals(jobId) ? target : null),
+				rescheduleJob: async (id, runAt) => {
+					coreCalls.push({ id, runAt });
+
+					return rescheduled;
+				},
+			}),
+		});
+
+		const response = await handlePost(
+			surface,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/reschedule`,
+			{ nextRunAt: '2026-02-01T10:30:00.000Z' },
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			id: jobId.toHexString(),
+			nextRunAt: '2026-02-01T10:30:00.000Z',
+			updatedAt: '2026-01-01T00:04:00.000Z',
+		});
+		expect(coreCalls).toEqual([
+			{
+				id: jobId.toHexString(),
+				runAt: new Date('2026-02-01T10:30:00.000Z'),
+			},
+		]);
+	});
 });

--- a/packages/management/tests/unit/orpc-single-job-actions.test.ts
+++ b/packages/management/tests/unit/orpc-single-job-actions.test.ts
@@ -1,0 +1,127 @@
+import type { CursorOptions, PersistedJob, QueueStats } from '@monque/core';
+import { ObjectId } from 'mongodb';
+import { describe, expect, test } from 'vitest';
+
+import { createManagementSurface } from '@/index';
+import type { ManagementMonque, ManagementOpenApiContext, ManagementSurface } from '@/surface';
+
+function createManagementMonque(overrides: Partial<ManagementMonque> = {}): ManagementMonque {
+	return {
+		isHealthy: () => true,
+		getQueueViewSummaries: async () => [],
+		getJobsWithCursor: async (_options?: CursorOptions) => ({
+			jobs: [],
+			cursor: null,
+			hasNextPage: false,
+			hasPreviousPage: false,
+		}),
+		getJob: async () => null,
+		getQueueStats: async (_filter?: { name?: string }): Promise<QueueStats> => ({
+			pending: 0,
+			processing: 0,
+			completed: 0,
+			failed: 0,
+			cancelled: 0,
+			total: 0,
+		}),
+		...overrides,
+	};
+}
+
+function createJob(overrides: Partial<PersistedJob> = {}): PersistedJob {
+	return {
+		_id: new ObjectId(),
+		name: 'send-email',
+		data: { to: 'person@example.test' },
+		status: 'pending',
+		nextRunAt: new Date('2026-01-01T00:00:00.000Z'),
+		failCount: 0,
+		createdAt: new Date('2025-12-31T23:00:00.000Z'),
+		updatedAt: new Date('2026-01-01T00:01:00.000Z'),
+		...overrides,
+	};
+}
+
+async function handlePost(
+	surface: ManagementSurface,
+	path: string,
+	body?: unknown,
+	context?: ManagementOpenApiContext,
+): Promise<Response> {
+	const init: RequestInit = { method: 'POST' };
+
+	if (body !== undefined) {
+		init.headers = { 'content-type': 'application/json' };
+		init.body = JSON.stringify(body);
+	}
+
+	const result = await surface.openApiHandler.handle(
+		new Request(`https://management.example${path}`, init),
+		context === undefined ? {} : { context },
+	);
+
+	if (!result.matched) {
+		throw new Error(`Expected oRPC OpenAPI handler to match ${path}`);
+	}
+
+	return result.response;
+}
+
+describe('oRPC Management single Job action routes', () => {
+	test('cancels one Job through public core API with target authorization', async () => {
+		const jobId = new ObjectId();
+		const target = createJob({ _id: jobId });
+		const cancelled = createJob({
+			_id: jobId,
+			status: 'cancelled',
+			updatedAt: new Date('2026-01-01T00:02:00.000Z'),
+		});
+		const coreCalls: string[] = [];
+		const authorizeCalls: unknown[] = [];
+		const surface = createManagementSurface<{ userId: string }>({
+			monque: createManagementMonque({
+				getJob: async (id) => (id.equals(jobId) ? target : null),
+				cancelJob: async (id) => {
+					coreCalls.push(id);
+
+					return cancelled;
+				},
+			}),
+			authorize: ({ action, context, job }) => {
+				authorizeCalls.push({ action, context, job });
+				return true;
+			},
+		});
+
+		const response = await handlePost(
+			surface,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/cancel`,
+			undefined,
+			{ managementContext: { userId: 'operator-1' } },
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			id: jobId.toHexString(),
+			name: 'send-email',
+			status: 'cancelled',
+			payload: { to: 'person@example.test' },
+			nextRunAt: '2026-01-01T00:00:00.000Z',
+			lockedAt: null,
+			claimedBy: null,
+			lastHeartbeat: null,
+			failCount: 0,
+			failureReason: null,
+			createdAt: '2025-12-31T23:00:00.000Z',
+			updatedAt: '2026-01-01T00:02:00.000Z',
+		});
+		expect(coreCalls).toEqual([jobId.toHexString()]);
+		expect(authorizeCalls).toEqual([
+			{
+				action: 'cancel',
+				context: { userId: 'operator-1' },
+				job: target,
+			},
+		]);
+	});
+});

--- a/packages/management/tests/unit/orpc-single-job-actions.test.ts
+++ b/packages/management/tests/unit/orpc-single-job-actions.test.ts
@@ -124,4 +124,42 @@ describe('oRPC Management single Job action routes', () => {
 			},
 		]);
 	});
+
+	test('retries one Job through public core API', async () => {
+		const jobId = new ObjectId();
+		const target = createJob({
+			_id: jobId,
+			status: 'failed',
+			failCount: 2,
+			updatedAt: new Date('2026-01-01T00:02:00.000Z'),
+		});
+		const retried = createJob({
+			_id: jobId,
+			status: 'pending',
+			failCount: 2,
+			updatedAt: new Date('2026-01-01T00:03:00.000Z'),
+		});
+		const coreCalls: string[] = [];
+		const surface = createManagementSurface({
+			monque: createManagementMonque({
+				getJob: async (id) => (id.equals(jobId) ? target : null),
+				retryJob: async (id) => {
+					coreCalls.push(id);
+
+					return retried;
+				},
+			}),
+		});
+
+		const response = await handlePost(surface, `/api/v1/jobs/${jobId.toHexString()}/actions/retry`);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			id: jobId.toHexString(),
+			status: 'pending',
+			failCount: 2,
+			updatedAt: '2026-01-01T00:03:00.000Z',
+		});
+		expect(coreCalls).toEqual([jobId.toHexString()]);
+	});
 });

--- a/packages/management/tests/unit/orpc-single-job-actions.test.ts
+++ b/packages/management/tests/unit/orpc-single-job-actions.test.ts
@@ -1,4 +1,9 @@
-import type { CursorOptions, PersistedJob, QueueStats } from '@monque/core';
+import {
+	type CursorOptions,
+	JobStateError,
+	type PersistedJob,
+	type QueueStats,
+} from '@monque/core';
 import { ObjectId } from 'mongodb';
 import { describe, expect, test } from 'vitest';
 
@@ -240,5 +245,133 @@ describe('oRPC Management single Job action routes', () => {
 				runAt: new Date('2026-02-01T10:30:00.000Z'),
 			},
 		]);
+	});
+
+	test('maps single Job action failures to stable HTTP statuses', async () => {
+		const jobId = new ObjectId();
+		const target = createJob({ _id: jobId });
+		const coreCalls: string[] = [];
+		const readOnly = createManagementSurface({
+			monque: createManagementMonque({
+				cancelJob: async () => {
+					coreCalls.push('read-only');
+
+					return null;
+				},
+			}),
+			readOnly: true,
+		});
+		const unsupported = createManagementSurface({
+			monque: createManagementMonque(),
+		});
+		const denied = createManagementSurface<{ role: string }>({
+			monque: createManagementMonque({
+				getJob: async (id) => (id.equals(jobId) ? target : null),
+				cancelJob: async () => {
+					coreCalls.push('denied');
+
+					return null;
+				},
+			}),
+			authorize: ({ action, context, job }) => {
+				expect({ action, context, job }).toEqual({
+					action: 'cancel',
+					context: { role: 'viewer' },
+					job: target,
+				});
+
+				return false;
+			},
+		});
+		const validatesBeforeCore = createManagementSurface({
+			monque: createManagementMonque({
+				getJob: async () => {
+					coreCalls.push('invalid');
+
+					return target;
+				},
+				cancelJob: async () => {
+					coreCalls.push('invalid');
+
+					return target;
+				},
+				rescheduleJob: async () => {
+					coreCalls.push('invalid');
+
+					return target;
+				},
+			}),
+		});
+		const missing = createManagementSurface({
+			monque: createManagementMonque({
+				getJob: async () => null,
+				cancelJob: async () => {
+					coreCalls.push('missing');
+
+					return null;
+				},
+			}),
+		});
+		const conflict = createManagementSurface({
+			monque: createManagementMonque({
+				getJob: async (id) => (id.equals(jobId) ? target : null),
+				cancelJob: async () => {
+					throw new JobStateError(
+						'Cannot cancel processing job',
+						jobId.toHexString(),
+						'processing',
+						'cancel',
+					);
+				},
+			}),
+		});
+
+		const readOnlyResponse = await handlePost(
+			readOnly,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/cancel`,
+		);
+		const unsupportedResponse = await handlePost(
+			unsupported,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/cancel`,
+		);
+		const deniedResponse = await handlePost(
+			denied,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/cancel`,
+			undefined,
+			{ managementContext: { role: 'viewer' } },
+		);
+		const invalidId = await handlePost(
+			validatesBeforeCore,
+			'/api/v1/jobs/not-an-object-id/actions/cancel',
+		);
+		const invalidRescheduleBody = await handlePost(
+			validatesBeforeCore,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/reschedule`,
+			{ nextRunAt: 'February 1, 2026 10:30:00' },
+		);
+		const missingResponse = await handlePost(
+			missing,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/cancel`,
+		);
+		const conflictResponse = await handlePost(
+			conflict,
+			`/api/v1/jobs/${jobId.toHexString()}/actions/cancel`,
+		);
+
+		expect(readOnlyResponse.status).toBe(403);
+		expect(await readOnlyResponse.json()).toEqual({ error: 'Management surface is read-only' });
+		expect(unsupportedResponse.status).toBe(403);
+		expect(await unsupportedResponse.json()).toEqual({ error: 'Unsupported action' });
+		expect(deniedResponse.status).toBe(403);
+		expect(await deniedResponse.json()).toEqual({ error: 'Action denied' });
+		expect(invalidId.status).toBe(400);
+		expect(await invalidId.json()).toEqual({ error: 'Invalid job id' });
+		expect(invalidRescheduleBody.status).toBe(400);
+		expect(await invalidRescheduleBody.json()).toEqual({ error: 'Input validation failed' });
+		expect(missingResponse.status).toBe(404);
+		expect(await missingResponse.json()).toEqual({ error: 'Job not found' });
+		expect(conflictResponse.status).toBe(409);
+		expect(await conflictResponse.json()).toEqual({ error: 'Cannot cancel processing job' });
+		expect(coreCalls).toEqual([]);
 	});
 });

--- a/packages/management/tests/unit/orpc-single-job-actions.test.ts
+++ b/packages/management/tests/unit/orpc-single-job-actions.test.ts
@@ -67,6 +67,23 @@ async function handlePost(
 	return result.response;
 }
 
+async function handleDelete(
+	surface: ManagementSurface,
+	path: string,
+	context?: ManagementOpenApiContext,
+): Promise<Response> {
+	const result = await surface.openApiHandler.handle(
+		new Request(`https://management.example${path}`, { method: 'DELETE' }),
+		context === undefined ? {} : { context },
+	);
+
+	if (!result.matched) {
+		throw new Error(`Expected oRPC OpenAPI handler to match ${path}`);
+	}
+
+	return result.response;
+}
+
 describe('oRPC Management single Job action routes', () => {
 	test('cancels one Job through public core API with target authorization', async () => {
 		const jobId = new ObjectId();
@@ -160,6 +177,28 @@ describe('oRPC Management single Job action routes', () => {
 			failCount: 2,
 			updatedAt: '2026-01-01T00:03:00.000Z',
 		});
+		expect(coreCalls).toEqual([jobId.toHexString()]);
+	});
+
+	test('deletes one Job through public core API with a stable response DTO', async () => {
+		const jobId = new ObjectId();
+		const target = createJob({ _id: jobId, status: 'completed' });
+		const coreCalls: string[] = [];
+		const surface = createManagementSurface({
+			monque: createManagementMonque({
+				getJob: async (id) => (id.equals(jobId) ? target : null),
+				deleteJob: async (id) => {
+					coreCalls.push(id);
+
+					return true;
+				},
+			}),
+		});
+
+		const response = await handleDelete(surface, `/api/v1/jobs/${jobId.toHexString()}`);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ deleted: true });
 		expect(coreCalls).toEqual([jobId.toHexString()]);
 	});
 });

--- a/packages/management/tests/unit/package-contract.test.ts
+++ b/packages/management/tests/unit/package-contract.test.ts
@@ -6,11 +6,13 @@ import { describe, expect, test } from 'vitest';
 import {
 	BulkActionResultDtoSchema,
 	CapabilitiesDtoSchema,
+	DeleteJobDtoSchema,
 	JobCursorPageDtoSchema,
 	JobDtoSchema,
 	JobSelectorDtoSchema,
 	QueueStatsDtoSchema,
 	QueueViewSummaryListDtoSchema,
+	RescheduleJobRequestDtoSchema,
 } from '@/index';
 
 interface PackageJson {
@@ -146,6 +148,19 @@ describe('@monque/management package contract', () => {
 			BulkActionResultDtoSchema.safeParse({
 				count: 1,
 				errors: [{ jobId: 'job-1', error: 'still processing' }],
+			}).success,
+		).toBe(true);
+	});
+
+	test('exports the Zod-derived single Job action DTO schemas', () => {
+		expect(
+			RescheduleJobRequestDtoSchema.safeParse({
+				nextRunAt: '2026-02-01T10:30:00.000Z',
+			}).success,
+		).toBe(true);
+		expect(
+			DeleteJobDtoSchema.safeParse({
+				deleted: true,
 			}).success,
 		).toBe(true);
 	});


### PR DESCRIPTION
## Summary

- Adds oRPC single-job cancel, retry, reschedule, and delete routes.
- Adds Zod-derived reschedule and delete DTO schemas/exports.
- Covers single-job action behavior and generated OpenAPI contract.

## Verification

- `packages/management`: `bun run test:unit`
- repo: `bun run check`
- repo: `bun run test:unit`

Closes #440
