### PR TITLE
docs: define dashboard architecture plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,6 +31,10 @@ _Avoid_: dashboard plugin
 by Management Adapters, OpenAPI generation, and Dashboard clients.
 _Avoid_: dashboard routes, adapter routes
 
+**Dashboard** — bundled operator UI for inspecting Queue Views and operating Jobs through
+the Management Route Map.
+_Avoid_: dashboard server, management adapter
+
 **Scheduler Instance** — running Monque process identified by `schedulerInstanceId`.
 It claims jobs, sends heartbeats, and releases ownership when work completes.
 
@@ -60,6 +64,32 @@ processing jobs block duplicates; completed and failed jobs do not.
 - Claims and owned-job transitions use atomic MongoDB preconditions.
 - A Queue View is derived from job names; it is not a persisted queue entity.
 - The Management Surface is separate from the Dashboard; the Dashboard is one possible client.
+- The Dashboard is an asset/UI-only client package; serving it is outside the Dashboard
+  package itself.
+- Dashboard serving adapters are framework-specific packages that serve bundled Dashboard
+  assets and SPA fallback; they are not Management Adapters.
+- Dashboard serving adapters inject mount-aware runtime configuration, including the
+  Management API base URL, so Dashboard assets do not need rebuilding per mount path.
+- Dashboard serving adapters expose mount-aware options such as `basePath` and
+  `apiBaseUrl`; host applications compose authentication middleware around them.
+- Dashboard serving adapters serve only Dashboard UI assets and do not mount the Management
+  API.
+- Host applications compose Dashboard serving adapters with Management Adapters and should
+  protect both UI and API mounts with authentication middleware when needed.
+- Dashboard runtime configuration is strictly validated at app boot; production builds do
+  not silently guess mount paths when config is missing.
+- The Dashboard package ships an HTML template and hashed assets; serving adapters inject
+  runtime configuration into the template and serve SPA fallbacks.
+- The Dashboard package exports asset metadata and runtime config types for serving
+  adapters; it does not expose a React component library in v1.
+- Dashboard development uses an unpublished repo-local dev shell separate from the published
+  asset/UI package.
+- Dashboard development mock mode uses oRPC mock Management handlers backed by seeded,
+  deterministic scenario factories.
+- Dashboard tests use mock Management handlers for UI integration; real MongoDB/Testcontainers
+  remain in core and Management integration tests.
+- Dashboard releases require Playwright smoke coverage for routing, core workflows, and
+  responsive layout sanity.
 - Framework-specific middleware belongs in Management Adapters, not in the Management Surface.
 - Standalone Dashboard and Docker distribution come after the Management Surface and at least
   one Management Adapter.
@@ -94,8 +124,49 @@ processing jobs block duplicates; completed and failed jobs do not.
   payload schemas first.
 - The Management Route Map is defined before the Dashboard, shared by adapters and clients,
   and uses an internal `/api/v1` prefix.
+- Dashboard code imports Management Route Map type/runtime contract data from a
+  browser-safe `@monque/management/contract` subpath, not from the Management Surface root.
+- The Management contract subpath exports the runtime Management contract plus all
+  Management DTO schemas and DTO types, but no server or Management Surface APIs.
+- The Dashboard package may depend on `@monque/management` at runtime only through the
+  browser-safe Management contract subpath.
+- Dashboard packages that consume the Management contract are versioned and released with
+  compatible Management contract changes.
+- Dashboard implementation starts with Management contract and Dashboard-grade listing
+  prerequisites before building the React UI.
+- Dashboard work release order is core listing support, Management contract/query support,
+  Dashboard asset package, then Dashboard serving adapter.
 - The Dashboard uses the same REST-shaped Management Route Map routes as third-party HTTP
   clients; there is no separate RPC-shaped Dashboard API.
+- The first Dashboard supports Queue Views, Job listing, Job details, scheduler health,
+  capabilities, and existing Job actions from the Management Route Map.
+- The first Dashboard uses Queue Views as its landing experience instead of synthetic KPI
+  cards; broader Overview metrics wait for explicit observability APIs.
+- The first Dashboard route set is Queue Views overview, Queue View detail by Job Name,
+  global Jobs table, Job detail, and health/capabilities.
+- Queue View detail shows Queue View summary information above the filtered Jobs table.
+- The Dashboard provides route navigation for switching between primary operator views.
+- The Dashboard uses a desktop sidebar and mobile drawer for primary navigation.
+- The Dashboard v1 accessibility baseline includes keyboard-navigable core workflows,
+  visible focus states, accessible action names, and non-color-only status communication.
+- Dashboard routes are resource-based; Job actions are in-screen controls, not separate
+  pages.
+- Dashboard filters and selections use URL state where practical so operator views can be
+  shared.
+- Dashboard URL state and Management query parameters use the same names where practical;
+  UI copy says Job Name even when the parameter is `name`.
+- Queue View detail routes imply the Job Name filter from the route and do not expose a
+  conflicting Job Name filter control.
+- Dashboard tables expose only server-backed sorting and filtering; the Dashboard does not
+  pretend to sort or filter beyond the current paginated result set.
+- Dashboard row selection is local client state, not URL state, so shared URLs do not carry
+  bulk-action selections.
+- The first Dashboard bulk actions operate only on explicitly selected Jobs and require
+  confirmation before execution.
+- The first Dashboard supports only operator-safe hotkeys; destructive Job actions are not
+  triggered directly by keyboard shortcuts.
+- The first Dashboard command palette is limited to navigation and safe view actions, not
+  destructive Job actions.
 - The Management Route Map groups operations by resource and uses action endpoints for job
   state transitions.
 - Management Adapters mount the oRPC OpenAPI HTTP handler instead of translating requests
@@ -105,6 +176,19 @@ processing jobs block duplicates; completed and failed jobs do not.
 - Job listing in the Management Route Map uses cursor pagination, not offset pagination.
 - Job listing filters in the Management Route Map only expose filters supported by public
   cursor listing in core.
+- Dashboard-grade Job listing requires server-backed date filters and whitelisted server
+  sorting in core and the Management Route Map before the UI exposes those controls.
+- The first Dashboard waits for Dashboard-grade Job listing rather than shipping a weak Jobs
+  table with only name and status filters.
+- Dashboard-grade cursor listing uses explicit whitelisted sort fields with a stable `_id`
+  tie-breaker; the default management browsing order is newest-created Jobs first.
+- Dashboard-grade cursor listing is added to core without breaking existing public
+  `getJobsWithCursor` calls.
+- Core cursor listing preserves public compatibility, while Management may explicitly choose
+  a Dashboard-oriented default sort for browsing.
+- Core owns practical index coverage for Dashboard-grade Job listing filters and sorts.
+- Dashboard-grade Job listing exposes created, updated, and next-run date filters first;
+  locked and heartbeat time filters are deferred.
 - Bulk job actions in the Management Route Map use a Management selector DTO that mirrors
   public core selector semantics and maps HTTP date strings to core `Date` values.
 - Invalid job state transitions in the Management Route Map are conflicts, not validation
@@ -122,6 +206,26 @@ processing jobs block duplicates; completed and failed jobs do not.
 - Management payload serialization can be configured globally and per job name.
 - Management payload serialization receives request or authorization context so payload
   visibility can vary per user.
+- Dashboard payload display is read-only; payload redaction belongs to Management payload
+  serialization, not Dashboard-side hiding.
+- Dashboard date display uses `date-fns`; timezone conversion uses `@date-fns/tz` only when
+  explicit timezone handling is needed.
+- Dashboard reusable UI components are shadcn-first, including compatible shadcn ecosystem
+  registries when they fit.
+- Dashboard feature components may compose shadcn primitives around domain concepts; Tailwind
+  is used for layout and local composition rather than hand-rolling reusable primitives.
+- Dashboard forms use TanStack Form for non-trivial forms and Zod v4 validation where client
+  validation is useful; simple controls do not require form machinery.
+- Dashboard validation reuses Management contract schemas for API wire contracts and uses
+  Dashboard-local schemas for UI state before serialization.
+- Dashboard data fetching uses oRPC TanStack Query utilities inside the Dashboard package
+  rather than hand-written API hook layers where generated utilities fit.
+- Dashboard Job listing uses normal query options with explicit cursor URL state, not
+  infinite-query behavior.
+- Dashboard builds use Vite-compatible bundling with route-level code splitting and bundle
+  visualization before release; the first Dashboard has no hard bundle byte budget.
+- The first Dashboard supports light, dark, and system theme modes; deeper visual design is
+  handled in the Dashboard implementation rather than domain policy.
 - The Management Surface exports an OpenAPI contract derived from the Management Route Map;
   adapters may serve it but do not generate it independently.
 - The Management OpenAPI contract includes all v1 routes and does not vary by mounted
@@ -141,10 +245,18 @@ processing jobs block duplicates; completed and failed jobs do not.
   documentation UI paths.
 - The first Management Route Map is request/response only; Dashboard freshness uses polling,
   not SSE or WebSocket.
+- Dashboard polling is screen-aware and must preserve valid local row selections across
+  refreshes.
 - Management health starts as a simple scheduler health DTO; deeper diagnostics require
   public core read APIs first.
 - Authentication belongs to the hosting application or Management Adapter; the Management
   Surface may enforce optional operation authorization hooks.
+- Dashboard API requests include browser credentials by default, while authentication remains
+  host-owned and no Dashboard login screen exists in v1.
+- Dashboard uses standard TanStack Router pending, error, and not-found boundaries at the
+  root with route-level overrides where needed.
+- Dashboard error handling uses oRPC typed errors where possible so Management API failures
+  map to specific operator-facing states.
 - The first Management Surface supports operation authorization, not Queue View visibility
   filtering.
 - Management operation authorization is action-grained.

--- a/apps/docs/src/content/docs/roadmap.mdx
+++ b/apps/docs/src/content/docs/roadmap.mdx
@@ -24,9 +24,10 @@ do not commit to a delivery timeline.
   {
     title: 'Dashboard',
     status: 'planned',
-    description: 'A UI for inspecting queues and operating existing Jobs through the Management Surface.',
+    description: 'A bundled operator UI for inspecting Queue Views and operating existing Jobs through the Management Surface.',
     features: [
-      'Use the same REST-shaped Management routes as HTTP clients',
+      'Ship as an asset/UI package that can be served by framework-specific adapters',
+      'Use the same REST-shaped Management routes as HTTP clients with first-party oRPC typing',
       'Start with polling and existing Job actions',
       'Defer realtime updates, Job creation, and visibility filtering until core APIs support them'
     ]
@@ -48,7 +49,7 @@ do not commit to a delivery timeline.
     features: [
       'Namespace-aware or multi-tenant operations',
       'Rate limits, priority controls, and operational policy hooks',
-      'Standalone server or Docker packaging if embedded adapters are not enough'
+      'Standalone Dashboard server or Docker packaging after the bundled Dashboard and serving adapters exist'
     ]
   }
 ]} />

--- a/docs/adr/0006-dashboard-asset-package-and-serving-adapters.md
+++ b/docs/adr/0006-dashboard-asset-package-and-serving-adapters.md
@@ -1,0 +1,35 @@
+# ADR-0006: Dashboard Asset Package And Serving Adapters
+
+## Status
+
+Accepted
+
+## Context
+
+Monque needs a bundled React Dashboard that can be served from host backends while keeping
+the Management Surface framework-neutral. The Dashboard should use the same Management Route
+Map as other clients and should not create a Dashboard-only API.
+
+## Decision
+
+`@monque/dashboard` is an asset/UI-only package. It ships a built React SPA, an HTML
+template, hashed assets, asset metadata helpers, and runtime config types. It does not mount
+HTTP routes, expose a React component library, depend on `@monque/core`, or talk directly to
+MongoDB.
+
+Dashboard serving is handled by framework-specific serving adapters such as
+`@monque/dashboard-express`. These adapters serve Dashboard assets and SPA fallbacks only;
+they do not mount the Management API. Host applications compose Dashboard serving adapters
+with Management Adapters, authentication middleware, and authorization hooks.
+
+Serving adapters inject mount-aware runtime configuration, including the Dashboard base path
+and Management API base URL, into the Dashboard HTML template. The Dashboard imports the
+browser-safe `@monque/management/contract` subpath for oRPC end-to-end typing and calls the
+mounted Management Route Map through the oRPC OpenAPI client.
+
+## Consequences
+
+The same Dashboard build can be served at different mount paths without rebuilding. Future
+framework adapters, standalone servers, and Docker images wrap the same asset package instead
+of changing the Dashboard runtime boundary. Management API routing remains owned by
+Management Adapters, and Dashboard serving remains a separate composition concern.

--- a/docs/research/dashboard-architecture-stack.md
+++ b/docs/research/dashboard-architecture-stack.md
@@ -1,0 +1,259 @@
+# Dashboard Architecture Stack
+
+This note records research for the first bundled Monque Dashboard. It is research input for
+a PRD and issue breakdown, not a normative contract. Normative decisions live in
+`CONTEXT.md` and ADRs.
+
+Research date: 2026-05-11.
+
+## Context
+
+The Dashboard should be a bundled React SPA that can be served by backend adapters. It
+should inspect Queue Views and operate existing Jobs through the Management Route Map. It
+should not mount the Management API, talk to MongoDB, expose a React component library, or
+create a Dashboard-only API.
+
+## Package Shape
+
+Findings:
+
+- Vite production builds include referenced assets in the build graph, generate hashed file
+  names, and can produce split chunks.
+- Express can serve static assets, but framework-specific SPA fallback and runtime config
+  injection belong in a serving adapter, not in the Dashboard asset package.
+
+Implications:
+
+- `@monque/dashboard` should ship an HTML template, hashed assets, a manifest or asset
+  metadata helper, and runtime config types.
+- Serving adapters such as `@monque/dashboard-express` should inject `basePath` and
+  `apiBaseUrl` into the HTML template, serve hashed assets with long cache headers, and serve
+  HTML with no-cache headers.
+- The same Dashboard build can be served under different mount paths without rebuilding.
+
+Sources:
+
+- Vite static asset handling: https://vite.dev/guide/assets.html
+- Vite production build: https://vite.dev/guide/build
+- Express static files: https://expressjs.com/en/starter/static-files.html
+
+## Router And URL State
+
+Findings:
+
+- TanStack Router validates and types search params through route `validateSearch`.
+- Search params can be read in loaders/components and written with router navigation APIs.
+- TanStack Router supports route code splitting. With file-based routing and the Vite
+  bundler plugin, automatic route code splitting can split non-critical route code.
+
+Implications:
+
+- Dashboard filters, pagination cursors, limits, and sort parameters should use TanStack
+  Router search state.
+- Row selection should remain local state because copied URLs must not carry bulk-action
+  selections.
+- The Dashboard should use TanStack Router with Vite plugin support and route-level code
+  splitting.
+
+Sources:
+
+- TanStack Router search params: https://tanstack.com/router/latest/docs/framework/react/guide/search-params
+- TanStack Router search validation: https://tanstack.com/router/latest/docs/how-to/validate-search-params
+- TanStack Router code splitting: https://tanstack.com/router/latest/docs/framework/react/guide/code-splitting
+
+## oRPC Client And TanStack Query
+
+Findings:
+
+- oRPC `OpenAPILink` lets a client call an OpenAPIHandler-compatible API through
+  HTTP/Fetch from a contract router.
+- `OpenAPILink` accepts a custom `fetch`, so Dashboard API calls can include browser
+  credentials for host-owned cookie/session authentication.
+- `@orpc/tanstack-query` provides `createTanstackQueryUtils(client)`, including
+  `.queryOptions`, `.infiniteOptions`, `.mutationOptions`, and key helpers.
+- oRPC client error handling supports typed error checks through `isDefinedError`.
+
+Implications:
+
+- `@monque/dashboard` should import the runtime Management contract from
+  `@monque/management/contract`, create an oRPC `OpenAPILink`, and wrap it with
+  `createTanstackQueryUtils`.
+- Dashboard Job listing should use normal `.queryOptions` because cursor state is explicit
+  and URL-backed; infinite-query behavior is not needed in v1.
+- Mutation handlers should use oRPC keys/utilities for invalidation and typed oRPC errors
+  for operator-facing error states.
+
+Sources:
+
+- oRPC OpenAPILink: https://orpc.dev/docs/openapi/client/openapi-link
+- oRPC TanStack Query integration: https://orpc.dev/docs/integrations/tanstack-query
+- oRPC client error handling: https://orpc.dev/docs/client/error-handling
+
+## Mock Data And Dev Shell
+
+Findings:
+
+- oRPC's `implement` helper can create alternative router/procedure implementations for
+  testing and frontend mock servers.
+- Interface Forge provides Faker-backed, type-safe factories, optional Zod integration, and
+  deterministic seeded generation.
+
+Implications:
+
+- `apps/dashboard-dev` should include mock mode first and live mode later.
+- Mock mode should use an oRPC mock Management router built from the same Management
+  contract, keeping the Dashboard client path production-like.
+- Interface Forge can generate base DTO fixtures from Zod schemas, but Monque should still
+  define scenario factories so Job states remain coherent.
+- Faker and Interface Forge versions should be pinned closely enough to avoid visual test
+  drift from generated fixture changes.
+
+Sources:
+
+- oRPC testing and mocking: https://orpc.dev/docs/advanced/testing-mocking
+- Interface Forge npm package: https://www.npmjs.com/package/interface-forge
+
+## Tables
+
+Findings:
+
+- TanStack Table supports manual server-side pagination by setting `manualPagination`.
+- TanStack Table row selection state can be managed externally; with manual pagination,
+  selected row models only reflect rows in the current page, while selection state can still
+  contain IDs not present in the current data array.
+- TanStack Table has first-class column visibility state.
+- shadcn's data table guidance is intentionally a composition guide rather than a single
+  universal component, because data tables have specific source, filtering, and sorting
+  requirements.
+
+Implications:
+
+- Dashboard Jobs tables should use TanStack Table in manual server-side mode.
+- The Dashboard should expose only server-backed filters and sorting, not client-side
+  filtering/sorting over a single cursor page.
+- Row selection should be controlled by Dashboard-local table/store state, with explicit
+  selected rows only for v1 bulk actions.
+- shadcn table primitives and shadcn-compatible registry pieces should be composed into
+  feature components such as `JobsTable`; they should not hide the server-backed nature of
+  the data.
+
+Sources:
+
+- TanStack Table pagination: https://tanstack.com/table/latest/docs/guide/pagination
+- TanStack Table row selection: https://tanstack.com/table/latest/docs/guide/row-selection
+- TanStack Table column visibility: https://tanstack.com/table/latest/docs/guide/column-visibility
+- shadcn Data Table: https://ui.shadcn.com/docs/components/data-table
+
+## Forms And Validation
+
+Findings:
+
+- TanStack Form supports Standard Schema validators directly.
+- Current TanStack Form docs list Zod as a supported Standard Schema library; no separate
+  Zod form adapter is needed.
+- Standard Schema validation does not provide transformed values, so UI state still needs
+  explicit serialization before API calls.
+
+Implications:
+
+- Use TanStack Form for non-trivial forms such as rescheduling and date-filter forms.
+- Use Management contract schemas for API wire contracts and Dashboard-local Zod schemas for
+  UI state such as date ranges and runtime config.
+- Do not add `@tanstack/zod-form-adapter`.
+
+Sources:
+
+- TanStack Form basic concepts: https://tanstack.com/form/latest/docs/framework/react/guides/basic-concepts
+- TanStack Form validation: https://tanstack.com/form/latest/docs/framework/react/guides/validation
+
+## Hotkeys And Command Palette
+
+Findings:
+
+- TanStack Hotkeys provides React hooks such as `useHotkey` and `useHotkeys`.
+- Hotkey registrations can carry metadata, and registrations can be introspected for shortcut
+  palettes/help screens.
+- shadcn's Command component is a command menu for search and quick actions, backed by
+  `cmdk`.
+
+Implications:
+
+- Use `@tanstack/react-hotkeys` for operator-safe shortcuts.
+- Use shadcn Command/Dialog primitives for command palette UI.
+- The v1 command palette should be limited to navigation and safe view actions; destructive
+  Job actions should stay behind visible controls and confirmation dialogs.
+
+Sources:
+
+- TanStack Hotkeys guide: https://tanstack.com/hotkeys/latest/docs/framework/react/guides/hotkeys
+- TanStack Hotkeys `useHotkey`: https://tanstack.com/hotkeys/latest/docs/framework/react/reference/functions/useHotkey
+- shadcn Command: https://ui.shadcn.com/docs/components/command
+
+## UI Component Policy
+
+Findings:
+
+- shadcn supports a registry model for distributing component source, hooks, pages, config,
+  rules, and other files.
+- shadcn-compatible registry components can be added as source and then adapted locally.
+- The shadcn Command and Data Table docs reinforce composition from primitives rather than
+  opaque design-system runtime packages.
+
+Implications:
+
+- Dashboard reusable primitives should be shadcn-first, including compatible shadcn ecosystem
+  registries when the source is small, readable, and dependency-light.
+- Local feature components are still expected, but they should compose shadcn primitives
+  around Monque domain concepts.
+- JSON viewer and cron display components from shadcn-compatible registries are candidates,
+  but their source should be reviewed before adoption.
+
+Sources:
+
+- shadcn registry: https://ui.shadcn.com/docs/registry
+- shadcn registry index: https://ui.shadcn.com/docs/registry/registry-index
+- shadcn Command: https://ui.shadcn.com/docs/components/command
+
+## Testing And Release Checks
+
+Findings:
+
+- Playwright supports screenshot capture and visual comparisons through
+  `expect(page).toHaveScreenshot()`.
+- Playwright warns that screenshots can vary by OS, browser, hardware, settings, and
+  headless mode, so visual baselines need a stable execution environment.
+- Playwright also publishes `@playwright/cli`, a command-line interface designed for coding
+  agents that need token-efficient browser automation.
+
+Implications:
+
+- Dashboard releases should require Playwright smoke coverage for route loading, core
+  workflows, error states, and responsive layout sanity.
+- Visual tests should focus on representative states and run in a controlled environment.
+- Core/Management tests should keep real MongoDB/Testcontainers coverage; Dashboard tests
+  should use mock Management handlers.
+- The Dashboard implementation plan should add `@playwright/cli` as repo-local agent tooling
+  so agents can inspect frontend behavior during development. It should not be added to any
+  published package runtime dependency set.
+
+Sources:
+
+- Playwright screenshots: https://playwright.dev/docs/screenshots
+- Playwright visual comparisons: https://playwright.dev/docs/test-snapshots
+- Playwright coding agents CLI: https://playwright.dev/docs/getting-started-cli
+
+## Recommended Direction
+
+1. Add additive Dashboard-grade listing support in `@monque/core`, including server-backed
+   filters, whitelisted sorting, stable compound cursors, and practical index coverage.
+2. Add `@monque/management/contract` and expose the new listing query shape in the
+   Management Route Map and OpenAPI document.
+3. Build `@monque/dashboard` as a Vite/TanStack Router React asset package using oRPC
+   `OpenAPILink`, `@orpc/tanstack-query`, TanStack Table/Form/Store/Hotkeys, shadcn
+   ecosystem components, Zod v4, and date-fns.
+4. Build `apps/dashboard-dev` with oRPC mock handlers and seeded deterministic scenario
+   factories.
+5. Build `@monque/dashboard-express` as a UI-only serving adapter that injects runtime
+   config and serves SPA fallbacks.
+6. Add other serving adapters, standalone server, and Docker only after the asset package and
+   Express serving path prove stable.

--- a/docs/research/dashboard-client-generation.md
+++ b/docs/research/dashboard-client-generation.md
@@ -4,6 +4,12 @@ This note compares OpenAPI-to-TypeScript client generation options for a future 
 Dashboard using TanStack Query. It is research input for a PRD, not a normative contract.
 Normative decisions live in `CONTEXT.md` and ADRs.
 
+Status update: ADR-0005 and the Dashboard architecture research now prefer an oRPC typed
+client for first-party Dashboard code through the browser-safe `@monque/management/contract`
+subpath. OpenAPI client generation remains relevant for third-party clients and as a
+fallback if the first-party oRPC path proves unsuitable. See
+[`dashboard-architecture-stack.md`](./dashboard-architecture-stack.md).
+
 ## Context
 
 The Dashboard should not import runtime code from `@monque/management` for API calls.


### PR DESCRIPTION
## Summary

- add ADR for Dashboard asset package and serving adapters
- record Dashboard architecture research and client-generation direction
- update roadmap and domain context with Dashboard package boundaries, route scope, polling, runtime config, and release order

## Verification

- pre-commit ran via git commit; docs-only checks were skipped by Lefthook

Refs #455