### PR TITLE
refactor(core): deepen pending notification routing

### DIFF
--- a/packages/core/src/scheduler/monque.ts
+++ b/packages/core/src/scheduler/monque.ts
@@ -36,6 +36,7 @@ import {
 	JobProcessor,
 	JobQueryService,
 	LifecycleManager,
+	PendingNotificationRouter,
 	type ResolvedMonqueOptions,
 	type SchedulerContext,
 } from './services/index.js';
@@ -146,6 +147,7 @@ export class Monque extends EventEmitter {
 	private _processor: JobProcessor | null = null;
 	private _changeStreamHandler: ChangeStreamHandler | null = null;
 	private _lifecycleManager: LifecycleManager | null = null;
+	private _pendingNotificationRouter: PendingNotificationRouter | null = null;
 
 	constructor(db: Db, options: MonqueOptions = {}) {
 		super();
@@ -217,9 +219,10 @@ export class Monque extends EventEmitter {
 			this._manager = new JobManager(ctx);
 			this._query = new JobQueryService(ctx);
 			this._processor = new JobProcessor(ctx);
-			this._changeStreamHandler = new ChangeStreamHandler(ctx, (targetNames) =>
-				this.handleChangeStreamPoll(targetNames),
+			this._pendingNotificationRouter = new PendingNotificationRouter(ctx, (targetNames) =>
+				this.handlePendingNotificationPoll(targetNames),
 			);
+			this._changeStreamHandler = new ChangeStreamHandler(ctx, this._pendingNotificationRouter);
 			this._lifecycleManager = new LifecycleManager(ctx);
 
 			this.isInitialized = true;
@@ -297,13 +300,13 @@ export class Monque extends EventEmitter {
 	}
 
 	/**
-	 * Handle a change-stream-triggered poll and reset the safety poll timer.
+	 * Handle a Pending Notification poll and reset the safety poll timer.
 	 *
-	 * Used as the `onPoll` callback for {@link ChangeStreamHandler}. Runs a
-	 * targeted poll for the given worker names, then resets the adaptive safety
+	 * Used as the `onPoll` callback for {@link PendingNotificationRouter}. Runs a
+	 * targeted poll for the given Worker names, then resets the adaptive safety
 	 * poll timer so it doesn't fire redundantly.
 	 */
-	private async handleChangeStreamPoll(targetNames?: ReadonlySet<string>): Promise<void> {
+	private async handlePendingNotificationPoll(targetNames?: ReadonlySet<string>): Promise<void> {
 		await this.processor.poll(targetNames);
 		this.lifecycleManager.resetPollTimer();
 	}
@@ -325,11 +328,11 @@ export class Monque extends EventEmitter {
 			emit: <K extends keyof MonqueEventMap>(event: K, payload: MonqueEventMap[K]) =>
 				this.emit(event, payload),
 			notifyPendingJob: (name: string, nextRunAt: Date) => {
-				if (!this.isRunning || !this._changeStreamHandler) {
+				if (!this.isRunning || !this._pendingNotificationRouter) {
 					return;
 				}
 
-				this._changeStreamHandler.notifyPendingJob(name, nextRunAt);
+				this._pendingNotificationRouter.notifyPendingJob(name, nextRunAt);
 			},
 			notifyJobFinished: () => this.onJobFinished(),
 			documentToPersistedJob: <T>(doc: WithId<Document>) => documentToPersistedJob<T>(doc),

--- a/packages/core/src/scheduler/services/change-stream-handler.ts
+++ b/packages/core/src/scheduler/services/change-stream-handler.ts
@@ -1,15 +1,9 @@
 import type { ChangeStream, ChangeStreamDocument, Document } from 'mongodb';
 
 import { JobStatus } from '@/jobs';
-import { toError } from '@/shared';
 
+import type { PendingNotificationRouter } from './pending-notification-router.js';
 import type { SchedulerContext } from './types.js';
-
-/** Minimum poll interval floor to prevent tight loops (ms) */
-const MIN_POLL_INTERVAL = 100;
-
-/** Grace period after nextRunAt before scheduling a wakeup poll (ms) */
-const POLL_GRACE_PERIOD = 200;
 
 /**
  * Internal service for MongoDB Change Stream lifecycle.
@@ -33,27 +27,15 @@ export class ChangeStreamHandler {
 	/** Maximum reconnection attempts before falling back to polling-only mode */
 	private readonly maxReconnectAttempts = 3;
 
-	/** Debounce timer for change stream event processing */
-	private debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
 	/** Timer ID for reconnection with exponential backoff */
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 	/** Whether the scheduler is currently using change streams */
 	private usingChangeStreams = false;
 
-	/** Job names collected during the current debounce window for targeted polling */
-	private pendingTargetNames: Set<string> = new Set();
-
-	/** Wakeup timer for the earliest known future job */
-	private wakeupTimer: ReturnType<typeof setTimeout> | null = null;
-
-	/** Time of the currently scheduled wakeup */
-	private wakeupTime: Date | null = null;
-
 	constructor(
 		private readonly ctx: SchedulerContext,
-		private readonly onPoll: (targetNames?: ReadonlySet<string>) => Promise<void>,
+		private readonly pendingNotifications: PendingNotificationRouter,
 	) {}
 
 	/**
@@ -173,10 +155,7 @@ export class ChangeStreamHandler {
 		// Slot-freed events: targeted poll for that worker to pick up waiting jobs
 		if (isSlotFreed) {
 			const jobName = fullDocument?.['name'] as string | undefined;
-			if (jobName) {
-				this.pendingTargetNames.add(jobName);
-			}
-			this.debouncedPoll();
+			this.pendingNotifications.notifyRunnableJob(jobName);
 			return;
 		}
 
@@ -185,88 +164,12 @@ export class ChangeStreamHandler {
 		const nextRunAt = fullDocument?.['nextRunAt'] as Date | undefined;
 
 		if (jobName && nextRunAt) {
-			this.notifyPendingJob(jobName, nextRunAt);
+			this.pendingNotifications.notifyPendingJob(jobName, nextRunAt);
 			return;
 		}
 
 		// Immediate job or missing metadata — collect for targeted/full poll
-		if (jobName) {
-			this.pendingTargetNames.add(jobName);
-		}
-		this.debouncedPoll();
-	}
-
-	/**
-	 * Notify the handler about a pending job created or updated by this process.
-	 *
-	 * Reuses the same routing logic as change stream events so local writes don't
-	 * depend on the MongoDB change stream cursor already being fully ready.
-	 *
-	 * @param jobName - Worker name for targeted polling
-	 * @param nextRunAt - When the job becomes eligible for processing
-	 */
-	notifyPendingJob(jobName: string, nextRunAt: Date): void {
-		if (!this.ctx.isRunning()) {
-			return;
-		}
-
-		if (nextRunAt.getTime() > Date.now()) {
-			this.scheduleWakeup(nextRunAt);
-			return;
-		}
-
-		this.pendingTargetNames.add(jobName);
-		this.debouncedPoll();
-	}
-
-	/**
-	 * Schedule a debounced poll with collected target names.
-	 *
-	 * Collects job names from multiple change stream events during the debounce
-	 * window, then triggers a single targeted poll for only those workers.
-	 */
-	private debouncedPoll(): void {
-		if (this.debounceTimer) {
-			clearTimeout(this.debounceTimer);
-		}
-
-		this.debounceTimer = setTimeout(() => {
-			this.debounceTimer = null;
-			const names = this.pendingTargetNames.size > 0 ? new Set(this.pendingTargetNames) : undefined;
-			this.pendingTargetNames.clear();
-			this.onPoll(names).catch((error: unknown) => {
-				this.ctx.emit('job:error', { error: toError(error) });
-			});
-		}, 100);
-	}
-
-	/**
-	 * Schedule a wakeup timer for a future-dated job.
-	 *
-	 * Maintains a single timer set to the earliest known future job's `nextRunAt`.
-	 * When the timer fires, triggers a full poll to pick up all due jobs.
-	 *
-	 * @param nextRunAt - When the future job should become ready
-	 */
-	private scheduleWakeup(nextRunAt: Date): void {
-		// Only update if this job is earlier than the current wakeup
-		if (this.wakeupTime && nextRunAt >= this.wakeupTime) {
-			return;
-		}
-
-		this.clearWakeupTimer();
-		this.wakeupTime = nextRunAt;
-
-		const delay = Math.max(nextRunAt.getTime() - Date.now() + POLL_GRACE_PERIOD, MIN_POLL_INTERVAL);
-
-		this.wakeupTimer = setTimeout(() => {
-			this.wakeupTime = null;
-			this.wakeupTimer = null;
-			// Full poll — there may be multiple jobs due at this time
-			this.onPoll().catch((error: unknown) => {
-				this.ctx.emit('job:error', { error: toError(error) });
-			});
-		}, delay);
+		this.pendingNotifications.notifyRunnableJob(jobName);
 	}
 
 	/**
@@ -349,22 +252,8 @@ export class ChangeStreamHandler {
 	 * the reconnect timer/attempts (callers manage reconnection lifecycle).
 	 */
 	private resetActiveState(): void {
-		if (this.debounceTimer) {
-			clearTimeout(this.debounceTimer);
-			this.debounceTimer = null;
-		}
-
-		this.pendingTargetNames.clear();
-		this.clearWakeupTimer();
+		this.pendingNotifications.close();
 		this.usingChangeStreams = false;
-	}
-
-	private clearWakeupTimer(): void {
-		if (this.wakeupTimer) {
-			clearTimeout(this.wakeupTimer);
-			this.wakeupTimer = null;
-		}
-		this.wakeupTime = null;
 	}
 
 	private closeChangeStream(): void {

--- a/packages/core/src/scheduler/services/index.ts
+++ b/packages/core/src/scheduler/services/index.ts
@@ -7,6 +7,7 @@ export { JobQueryService } from './job-query.js';
 export { JobSelection } from './job-selection.js';
 export { JobStateTransitions } from './job-state-transitions.js';
 export { CLEANUP_STATUSES, LifecycleManager } from './lifecycle-manager.js';
+export { PendingNotificationRouter } from './pending-notification-router.js';
 // Types
 export {
 	RETRYABLE_JOB_STATUSES,

--- a/packages/core/src/scheduler/services/pending-notification-router.ts
+++ b/packages/core/src/scheduler/services/pending-notification-router.ts
@@ -1,0 +1,123 @@
+import { toError } from '@/shared';
+
+import type { SchedulerContext } from './types.js';
+
+/** Minimum poll interval floor to prevent tight loops (ms) */
+const MIN_POLL_INTERVAL = 100;
+
+/** Grace period after nextRunAt before scheduling a wakeup poll (ms) */
+const POLL_GRACE_PERIOD = 200;
+
+/**
+ * Routes Pending Notifications into targeted polls or future wakeups.
+ *
+ * This module owns the local routing rules shared by MongoDB change streams and
+ * local writes. The change stream adapter only decides when a Job became relevant.
+ */
+export class PendingNotificationRouter {
+	/** Debounce timer for immediate Pending Notifications */
+	private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	/** Job names collected during the current debounce window for targeted polling */
+	private pendingTargetNames: Set<string> = new Set();
+
+	/** Wakeup timer for the earliest known future Job */
+	private wakeupTimer: ReturnType<typeof setTimeout> | null = null;
+
+	/** Time of the currently scheduled wakeup */
+	private wakeupTime: Date | null = null;
+
+	constructor(
+		private readonly ctx: SchedulerContext,
+		private readonly onPoll: (targetNames?: ReadonlySet<string>) => Promise<void>,
+	) {}
+
+	notifyPendingJob(jobName: string, nextRunAt: Date): void {
+		if (!this.ctx.isRunning()) {
+			return;
+		}
+
+		if (nextRunAt.getTime() > Date.now()) {
+			this.scheduleWakeup(nextRunAt);
+			return;
+		}
+
+		this.notifyRunnableJob(jobName);
+	}
+
+	notifyRunnableJob(jobName?: string): void {
+		if (!this.ctx.isRunning()) {
+			return;
+		}
+
+		if (jobName) {
+			this.pendingTargetNames.add(jobName);
+		}
+
+		this.debouncedPoll();
+	}
+
+	close(): void {
+		if (this.debounceTimer) {
+			clearTimeout(this.debounceTimer);
+			this.debounceTimer = null;
+		}
+
+		this.pendingTargetNames.clear();
+		this.clearWakeupTimer();
+	}
+
+	/**
+	 * Schedule a debounced poll with collected target names.
+	 *
+	 * Collects Job Names from multiple Pending Notifications during the debounce
+	 * window, then triggers a single targeted poll for only those Workers.
+	 */
+	private debouncedPoll(): void {
+		if (this.debounceTimer) {
+			clearTimeout(this.debounceTimer);
+		}
+
+		this.debounceTimer = setTimeout(() => {
+			this.debounceTimer = null;
+			const names = this.pendingTargetNames.size > 0 ? new Set(this.pendingTargetNames) : undefined;
+			this.pendingTargetNames.clear();
+			this.onPoll(names).catch((error: unknown) => {
+				this.ctx.emit('job:error', { error: toError(error) });
+			});
+		}, 100);
+	}
+
+	/**
+	 * Schedule a wakeup timer for a future-dated Job.
+	 *
+	 * Maintains a single timer set to the earliest known future Job's `nextRunAt`.
+	 * When the timer fires, triggers a full poll to pick up all due Jobs.
+	 */
+	private scheduleWakeup(nextRunAt: Date): void {
+		if (this.wakeupTime && nextRunAt >= this.wakeupTime) {
+			return;
+		}
+
+		this.clearWakeupTimer();
+		this.wakeupTime = nextRunAt;
+
+		const delay = Math.max(nextRunAt.getTime() - Date.now() + POLL_GRACE_PERIOD, MIN_POLL_INTERVAL);
+
+		this.wakeupTimer = setTimeout(() => {
+			this.wakeupTime = null;
+			this.wakeupTimer = null;
+			this.onPoll().catch((error: unknown) => {
+				this.ctx.emit('job:error', { error: toError(error) });
+			});
+		}, delay);
+	}
+
+	private clearWakeupTimer(): void {
+		if (this.wakeupTimer) {
+			clearTimeout(this.wakeupTimer);
+			this.wakeupTimer = null;
+		}
+		this.wakeupTime = null;
+	}
+}

--- a/packages/core/tests/integration/retry.test.ts
+++ b/packages/core/tests/integration/retry.test.ts
@@ -289,24 +289,21 @@ describe('Retry Logic', () => {
 			await monque.initialize();
 
 			let callCount = 0;
+			let failureEvents = 0;
 			monque.register<{ test: boolean }>(TEST_CONSTANTS.JOB_NAME, async () => {
 				callCount++;
 				throw new Error(`Failure #${callCount}`);
+			});
+
+			monque.on('job:fail', () => {
+				failureEvents++;
 			});
 
 			const job = await monque.enqueue(TEST_CONSTANTS.JOB_NAME, { test: true });
 			monque.start();
 
 			// Wait for second failure
-			await waitFor(
-				async () => {
-					const doc = (await db
-						.collection(collectionName)
-						.findOne({ _id: job._id })) as WithId<Document> | null;
-					return doc !== null && doc['failCount'] >= 2;
-				},
-				{ timeout: 5000 },
-			);
+			await waitFor(async () => failureEvents >= 2, { timeout: 5000 });
 
 			await monque.stop();
 

--- a/packages/core/tests/unit/services/change-stream-handler.test.ts
+++ b/packages/core/tests/unit/services/change-stream-handler.test.ts
@@ -12,10 +12,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMockContext } from '@tests/factories';
 import { JobStatus } from '@/jobs';
 import { ChangeStreamHandler } from '@/scheduler/services/change-stream-handler.js';
+import { PendingNotificationRouter } from '@/scheduler/services/pending-notification-router.js';
 
 describe('ChangeStreamHandler', () => {
 	let ctx: ReturnType<typeof createMockContext>;
 	let onPoll: (targetNames?: ReadonlySet<string>) => Promise<void>;
+	let pendingNotifications: PendingNotificationRouter;
 	let handler: ChangeStreamHandler;
 
 	beforeEach(() => {
@@ -23,10 +25,12 @@ describe('ChangeStreamHandler', () => {
 		onPoll = vi.fn().mockResolvedValue(undefined) as unknown as (
 			targetNames?: ReadonlySet<string>,
 		) => Promise<void>;
-		handler = new ChangeStreamHandler(ctx, onPoll);
+		pendingNotifications = new PendingNotificationRouter(ctx, onPoll);
+		handler = new ChangeStreamHandler(ctx, pendingNotifications);
 	});
 
 	afterEach(() => {
+		pendingNotifications.close();
 		vi.clearAllMocks();
 		vi.useRealTimers();
 	});
@@ -684,30 +688,6 @@ describe('ChangeStreamHandler', () => {
 			vi.advanceTimersByTime(6000);
 			expect(onPoll).not.toHaveBeenCalled();
 		});
-
-		it('should route locally notified immediate jobs through debounced targeted poll', () => {
-			vi.useFakeTimers();
-
-			handler.notifyPendingJob('local-immediate', new Date(Date.now() - 1000));
-
-			vi.advanceTimersByTime(150);
-
-			expect(onPoll).toHaveBeenCalledOnce();
-			expect(onPoll).toHaveBeenCalledWith(new Set(['local-immediate']));
-		});
-
-		it('should schedule wakeup for locally notified future jobs', () => {
-			vi.useFakeTimers();
-
-			handler.notifyPendingJob('local-future', new Date(Date.now() + 1000));
-
-			vi.advanceTimersByTime(1100);
-			expect(onPoll).not.toHaveBeenCalled();
-
-			vi.advanceTimersByTime(100);
-			expect(onPoll).toHaveBeenCalledOnce();
-			expect(onPoll).toHaveBeenCalledWith();
-		});
 	});
 
 	describe('handleEvent - mixed immediate and future', () => {
@@ -853,7 +833,8 @@ describe('ChangeStreamHandler', () => {
 			const pollError = new Error('Poll failed');
 			const failingOnPoll = vi.fn().mockRejectedValue(pollError);
 
-			const handlerWithFailingPoll = new ChangeStreamHandler(ctx, failingOnPoll);
+			const failingRouter = new PendingNotificationRouter(ctx, failingOnPoll);
+			const handlerWithFailingPoll = new ChangeStreamHandler(ctx, failingRouter);
 
 			const changeEvent = {
 				operationType: 'insert' as const,

--- a/packages/core/tests/unit/services/pending-notification-router.test.ts
+++ b/packages/core/tests/unit/services/pending-notification-router.test.ts
@@ -39,4 +39,113 @@ describe('PendingNotificationRouter', () => {
 		expect(onPoll).toHaveBeenCalledTimes(2);
 		expect(onPoll).toHaveBeenLastCalledWith();
 	});
+
+	it('deduplicates repeated immediate notifications for the same Job Name', () => {
+		const nextRunAt = new Date(Date.now() - 1000);
+
+		router.notifyPendingJob('email', nextRunAt);
+		router.notifyPendingJob('email', nextRunAt);
+
+		vi.advanceTimersByTime(150);
+
+		expect(onPoll).toHaveBeenCalledOnce();
+		expect(onPoll).toHaveBeenCalledWith(new Set(['email']));
+	});
+
+	it('does not route pending notifications when the scheduler is stopped', () => {
+		vi.mocked(ctx.isRunning).mockReturnValue(false);
+
+		router.notifyPendingJob('email', new Date(Date.now() - 1000));
+
+		vi.advanceTimersByTime(150);
+
+		expect(onPoll).not.toHaveBeenCalled();
+	});
+
+	it('does not route runnable notifications when the scheduler is stopped', () => {
+		vi.mocked(ctx.isRunning).mockReturnValue(false);
+
+		router.notifyRunnableJob('email');
+
+		vi.advanceTimersByTime(150);
+
+		expect(onPoll).not.toHaveBeenCalled();
+	});
+
+	it('routes runnable notifications without a Job Name as a full poll', () => {
+		router.notifyRunnableJob();
+
+		vi.advanceTimersByTime(150);
+
+		expect(onPoll).toHaveBeenCalledOnce();
+		expect(onPoll).toHaveBeenCalledWith(undefined);
+	});
+
+	it('allows close to be called repeatedly without polling', () => {
+		router.notifyPendingJob('email', new Date(Date.now() - 1000));
+		router.notifyPendingJob('late', new Date(Date.now() + 1000));
+
+		expect(() => {
+			router.close();
+			router.close();
+			router.close();
+		}).not.toThrow();
+
+		vi.advanceTimersByTime(1500);
+
+		expect(onPoll).not.toHaveBeenCalled();
+	});
+
+	it('emits job:error when polling rejects and continues routing later notifications', async () => {
+		const pollError = new Error('Poll failed');
+		onPoll = vi
+			.fn()
+			.mockRejectedValueOnce(pollError)
+			.mockResolvedValueOnce(undefined) as unknown as (
+			targetNames?: ReadonlySet<string>,
+		) => Promise<void>;
+		router.close();
+		router = new PendingNotificationRouter(ctx, onPoll);
+
+		router.notifyPendingJob('email', new Date(Date.now() - 1000));
+		await vi.advanceTimersByTimeAsync(150);
+
+		expect(ctx.emitHistory).toContainEqual({
+			event: 'job:error',
+			payload: { error: pollError },
+		});
+
+		router.notifyPendingJob('sms', new Date(Date.now() - 1000));
+		await vi.advanceTimersByTimeAsync(150);
+
+		expect(onPoll).toHaveBeenCalledTimes(2);
+		expect(onPoll).toHaveBeenLastCalledWith(new Set(['sms']));
+	});
+
+	it('keeps the earliest future wakeup when a later pending Job is notified', () => {
+		router.notifyPendingJob('early', new Date(Date.now() + 1000));
+		router.notifyPendingJob('late', new Date(Date.now() + 10_000));
+
+		vi.advanceTimersByTime(1250);
+
+		expect(onPoll).toHaveBeenCalledOnce();
+		expect(onPoll).toHaveBeenCalledWith();
+	});
+
+	it('emits job:error when a future wakeup poll rejects', async () => {
+		const pollError = new Error('Wakeup poll failed');
+		onPoll = vi.fn().mockRejectedValueOnce(pollError) as unknown as (
+			targetNames?: ReadonlySet<string>,
+		) => Promise<void>;
+		router.close();
+		router = new PendingNotificationRouter(ctx, onPoll);
+
+		router.notifyPendingJob('email', new Date(Date.now() + 1000));
+		await vi.advanceTimersByTimeAsync(1250);
+
+		expect(ctx.emitHistory).toContainEqual({
+			event: 'job:error',
+			payload: { error: pollError },
+		});
+	});
 });

--- a/packages/core/tests/unit/services/pending-notification-router.test.ts
+++ b/packages/core/tests/unit/services/pending-notification-router.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockContext } from '@tests/factories';
+import { PendingNotificationRouter } from '@/scheduler/services/pending-notification-router.js';
+
+describe('PendingNotificationRouter', () => {
+	let ctx: ReturnType<typeof createMockContext>;
+	let onPoll: (targetNames?: ReadonlySet<string>) => Promise<void>;
+	let router: PendingNotificationRouter;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		ctx = createMockContext();
+		onPoll = vi.fn().mockResolvedValue(undefined) as unknown as (
+			targetNames?: ReadonlySet<string>,
+		) => Promise<void>;
+		router = new PendingNotificationRouter(ctx, onPoll);
+	});
+
+	afterEach(() => {
+		router.close();
+		vi.clearAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('routes immediate Job Names together and wakes once for the earliest future Job', () => {
+		router.notifyPendingJob('email', new Date(Date.now() - 1000));
+		router.notifyPendingJob('sms', new Date(Date.now() - 1000));
+		router.notifyPendingJob('late', new Date(Date.now() + 10_000));
+		router.notifyPendingJob('early', new Date(Date.now() + 3000));
+
+		vi.advanceTimersByTime(150);
+
+		expect(onPoll).toHaveBeenCalledOnce();
+		expect(onPoll).toHaveBeenCalledWith(new Set(['email', 'sms']));
+
+		vi.advanceTimersByTime(3050);
+
+		expect(onPoll).toHaveBeenCalledTimes(2);
+		expect(onPoll).toHaveBeenLastCalledWith();
+	});
+});


### PR DESCRIPTION
## Summary
- add a PendingNotificationRouter module for Pending Notification debounce, targeted polls, and future wakeups
- make ChangeStreamHandler a MongoDB change-stream adapter that feeds the router
- wire local writes through the router and make the flaky retry integration wait on job:fail events

## Verification
- bun run test:integration tests/integration/retry.test.ts
- bun run check
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured scheduler's job notification routing to improve separation of concerns and maintainability. Pending job notifications are now routed through a dedicated handler that manages both immediate and scheduled job processing.
  * Enhanced error handling in the notification pipeline with consistent error normalization.
  * Updated test coverage to reflect the new notification architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ueberBrot/monque/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->