### PR TITLE
fix(core): notify after bulk retry

### DIFF
--- a/.changeset/friendly-bulk-notifications.md
+++ b/.changeset/friendly-bulk-notifications.md
@@ -1,0 +1,5 @@
+---
+'@monque/core': patch
+---
+
+Notify local schedulers after bulk retry moves jobs back to pending so retried jobs wake promptly instead of waiting for polling.

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
     },
     "packages/management": {
       "name": "@monque/management",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@orpc/contract": "^1.14.2",
         "@orpc/openapi": "^1.14.2",
@@ -89,7 +89,7 @@
     },
     "packages/management-express": {
       "name": "@monque/management-express",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@monque/core": "workspace:*",
         "@monque/management": "workspace:*",

--- a/packages/core/src/scheduler/monque.ts
+++ b/packages/core/src/scheduler/monque.ts
@@ -327,7 +327,7 @@ export class Monque extends EventEmitter {
 			isRunning: () => this.isRunning,
 			emit: <K extends keyof MonqueEventMap>(event: K, payload: MonqueEventMap[K]) =>
 				this.emit(event, payload),
-			notifyPendingJob: (name: string, nextRunAt: Date) => {
+			notifyPendingJob: (name: string | undefined, nextRunAt: Date) => {
 				if (!this.isRunning || !this._pendingNotificationRouter) {
 					return;
 				}

--- a/packages/core/src/scheduler/services/job-manager.ts
+++ b/packages/core/src/scheduler/services/job-manager.ts
@@ -1,8 +1,8 @@
-import { ObjectId } from 'mongodb';
+import { type Document, ObjectId } from 'mongodb';
 
 import { type BulkOperationResult, type JobSelector, JobStatus, type PersistedJob } from '@/jobs';
 import { buildSelectorQuery } from '@/scheduler';
-import { ConnectionError, MonqueError } from '@/shared';
+import { ConnectionError, MonqueError, toError } from '@/shared';
 
 import { JobStateTransitions } from './job-state-transitions.js';
 import {
@@ -10,6 +10,11 @@ import {
 	type RetryableJobStatusType,
 	type SchedulerContext,
 } from './types.js';
+
+type PendingNotificationDocument = Document & {
+	name?: unknown;
+	nextRunAt?: unknown;
+};
 
 /**
  * Internal service for job lifecycle management operations.
@@ -302,6 +307,10 @@ export class JobManager {
 
 			if (count > 0) {
 				this.ctx.emit('jobs:retried', { count });
+				await this.notifyRetriedPendingJobs(filter, now).catch((error: unknown) => {
+					this.ctx.emit('job:error', { error: toError(error) });
+					this.ctx.notifyPendingJob(filter.name, now);
+				});
 			}
 
 			return { count, errors: [] };
@@ -314,6 +323,32 @@ export class JobManager {
 				`Failed to retry jobs: ${message}`,
 				error instanceof Error ? { cause: error } : undefined,
 			);
+		}
+	}
+
+	/**
+	 * Emits local Pending Notifications for Jobs moved back to pending by bulk retry.
+	 *
+	 * The bulk update uses MongoDB-side staggered `nextRunAt` values, so this reads back the
+	 * changed Jobs by their shared `updatedAt` timestamp to preserve precise wakeup times.
+	 */
+	private async notifyRetriedPendingJobs(filter: JobSelector, updatedAt: Date): Promise<void> {
+		const query = buildRetryNotificationQuery(filter, updatedAt);
+		const cursor = this.ctx.collection.find<PendingNotificationDocument>(query, {
+			projection: { name: 1, nextRunAt: 1 },
+		});
+		const jobs = await cursor.toArray();
+
+		if (jobs.length === 0) {
+			this.ctx.notifyPendingJob(filter.name, updatedAt);
+			return;
+		}
+
+		for (const job of jobs) {
+			const name = typeof job.name === 'string' ? job.name : undefined;
+			const nextRunAt = job.nextRunAt instanceof Date ? job.nextRunAt : updatedAt;
+
+			this.ctx.notifyPendingJob(name, nextRunAt);
 		}
 	}
 
@@ -363,4 +398,31 @@ export class JobManager {
 			);
 		}
 	}
+}
+
+/**
+ * Build the post-retry lookup without the original terminal status filter.
+ *
+ * Retried Jobs are pending after the update, but name and created-at selector constraints still apply.
+ */
+function buildRetryNotificationQuery(filter: JobSelector, updatedAt: Date) {
+	const notificationFilter: JobSelector = {};
+
+	if (filter.name !== undefined) {
+		notificationFilter.name = filter.name;
+	}
+
+	if (filter.olderThan !== undefined) {
+		notificationFilter.olderThan = filter.olderThan;
+	}
+
+	if (filter.newerThan !== undefined) {
+		notificationFilter.newerThan = filter.newerThan;
+	}
+
+	const query = buildSelectorQuery(notificationFilter);
+	query['status'] = JobStatus.PENDING;
+	query['updatedAt'] = updatedAt;
+
+	return query;
 }

--- a/packages/core/src/scheduler/services/pending-notification-router.ts
+++ b/packages/core/src/scheduler/services/pending-notification-router.ts
@@ -32,7 +32,7 @@ export class PendingNotificationRouter {
 		private readonly onPoll: (targetNames?: ReadonlySet<string>) => Promise<void>,
 	) {}
 
-	notifyPendingJob(jobName: string, nextRunAt: Date): void {
+	notifyPendingJob(jobName: string | undefined, nextRunAt: Date): void {
 		if (!this.ctx.isRunning()) {
 			return;
 		}

--- a/packages/core/src/scheduler/services/types.ts
+++ b/packages/core/src/scheduler/services/types.ts
@@ -61,7 +61,7 @@ export interface SchedulerContext {
 	emit: <K extends keyof MonqueEventMap>(event: K, payload: MonqueEventMap[K]) => boolean;
 
 	/** Notify the local scheduler about a pending job transition */
-	notifyPendingJob: (name: string, nextRunAt: Date) => void;
+	notifyPendingJob: (name: string | undefined, nextRunAt: Date) => void;
 
 	/** Notify that a job has finished processing (for reactive shutdown drain) */
 	notifyJobFinished: () => void;

--- a/packages/core/tests/unit/services/job-manager.test.ts
+++ b/packages/core/tests/unit/services/job-manager.test.ts
@@ -453,7 +453,29 @@ describe('JobManager', () => {
 	});
 
 	describe('retryJobs', () => {
+		function mockRetryNotificationDocs(docs = JobFactory.buildList(1)) {
+			const mockCursor = {
+				toArray: vi.fn().mockResolvedValueOnce(docs),
+			};
+
+			vi.spyOn(ctx.mockCollection, 'find').mockReturnValueOnce(
+				mockCursor as unknown as ReturnType<typeof ctx.mockCollection.find>,
+			);
+
+			return mockCursor;
+		}
+
 		it('should retry all failed/cancelled jobs via updateMany with pipeline', async () => {
+			const bulkEmail = JobFactory.build({
+				name: 'bulk-email',
+				nextRunAt: new Date('2026-01-01T00:00:01.000Z'),
+			});
+			const bulkReport = JobFactory.build({
+				name: 'bulk-report',
+				nextRunAt: new Date('2026-01-01T00:00:02.000Z'),
+			});
+			const notificationJobs = [bulkEmail, bulkReport];
+			mockRetryNotificationDocs(notificationJobs);
 			vi.spyOn(ctx.mockCollection, 'updateMany').mockResolvedValueOnce({
 				modifiedCount: 5,
 				matchedCount: 5,
@@ -475,9 +497,19 @@ describe('JobManager', () => {
 			expect(ctx.emitHistory).toContainEqual(
 				expect.objectContaining({ event: 'jobs:retried', payload: { count: 5 } }),
 			);
+			expect(ctx.mockCollection.find).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: JobStatus.PENDING,
+					updatedAt: expect.any(Date),
+				}),
+				{ projection: { name: 1, nextRunAt: 1 } },
+			);
+			expect(ctx.notifyPendingJob).toHaveBeenCalledWith('bulk-email', bulkEmail.nextRunAt);
+			expect(ctx.notifyPendingJob).toHaveBeenCalledWith('bulk-report', bulkReport.nextRunAt);
 		});
 
 		it('should respect explicit status filter and intersect with retryable statuses', async () => {
+			mockRetryNotificationDocs([]);
 			vi.spyOn(ctx.mockCollection, 'updateMany').mockResolvedValueOnce({
 				modifiedCount: 3,
 				matchedCount: 3,
@@ -494,6 +526,7 @@ describe('JobManager', () => {
 			const [query] = retryCall ?? [];
 			expect(query).toEqual(expect.objectContaining({ status: 'failed' }));
 			expect(result).toEqual({ count: 3, errors: [] });
+			expect(ctx.notifyPendingJob).toHaveBeenCalledWith(undefined, expect.any(Date));
 		});
 
 		it('should return count 0 when filter status does not include retryable statuses', async () => {
@@ -520,7 +553,37 @@ describe('JobManager', () => {
 			);
 		});
 
+		it('should keep bulk retry successful when notification lookup fails', async () => {
+			const notificationError = new Error('Notification lookup failed');
+			const mockCursor = {
+				toArray: vi.fn().mockRejectedValueOnce(notificationError),
+			};
+
+			vi.spyOn(ctx.mockCollection, 'find').mockReturnValueOnce(
+				mockCursor as unknown as ReturnType<typeof ctx.mockCollection.find>,
+			);
+			vi.spyOn(ctx.mockCollection, 'updateMany').mockResolvedValueOnce({
+				modifiedCount: 1,
+				matchedCount: 1,
+				acknowledged: true,
+				upsertedCount: 0,
+				upsertedId: null,
+			});
+
+			const result = await manager.retryJobs({ name: 'bulk-retry' });
+
+			expect(result).toEqual({ count: 1, errors: [] });
+			expect(ctx.emitHistory).toContainEqual(
+				expect.objectContaining({
+					event: 'job:error',
+					payload: { error: notificationError },
+				}),
+			);
+			expect(ctx.notifyPendingJob).toHaveBeenCalledWith('bulk-retry', expect.any(Date));
+		});
+
 		it('should use pipeline-style update with $rand stagger', async () => {
+			mockRetryNotificationDocs([]);
 			vi.spyOn(ctx.mockCollection, 'updateMany').mockResolvedValueOnce({
 				modifiedCount: 1,
 				matchedCount: 1,

--- a/packages/core/tests/unit/services/pending-notification-router.test.ts
+++ b/packages/core/tests/unit/services/pending-notification-router.test.ts
@@ -81,6 +81,15 @@ describe('PendingNotificationRouter', () => {
 		expect(onPoll).toHaveBeenCalledWith(undefined);
 	});
 
+	it('routes immediate pending notifications without a Job Name as a full poll', () => {
+		router.notifyPendingJob(undefined, new Date(Date.now() - 1000));
+
+		vi.advanceTimersByTime(150);
+
+		expect(onPoll).toHaveBeenCalledOnce();
+		expect(onPoll).toHaveBeenCalledWith(undefined);
+	});
+
 	it('allows close to be called repeatedly without polling', () => {
 		router.notifyPendingJob('email', new Date(Date.now() - 1000));
 		router.notifyPendingJob('late', new Date(Date.now() + 1000));


### PR DESCRIPTION
Summary:
- Notify local schedulers after bulk retry moves jobs back to pending
- Fall back to a broad local notification if the post-retry lookup fails
- Add a patch changeset for @monque/core and include the lockfile update

Verification:
- bun run check
- bun run test:unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk retry operations now trigger scheduler notifications when jobs are moved back to pending status, enabling faster job execution instead of waiting for the next polling interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->